### PR TITLE
Clean up dependencies

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -66,7 +66,7 @@ init: ## pulls submodules and initializes virtual environment
 	git submodule update --init --recursive
 	which pdm || pip install --user pdm
 	pdm venv create -n $(PROJECT)
-	pdm install -d
+	pdm install -d -G :all
 
 node_modules: 
 ifeq (, $(shell which npm))

--- a/Makefile
+++ b/Makefile
@@ -66,7 +66,7 @@ init: ## pulls submodules and initializes virtual environment
 	git submodule update --init --recursive
 	which pdm || pip install --user pdm
 	pdm venv create -n $(PROJECT)
-	pdm install -d -G :all
+	pdm install -d -G train
 
 node_modules: 
 ifeq (, $(shell which npm))

--- a/mit_ub/__init__.py
+++ b/mit_ub/__init__.py
@@ -2,5 +2,8 @@
 # -*- coding: utf-8 -*-
 import importlib.metadata
 
+from .model import AdaptiveViT, ViT
+
 
 __version__ = importlib.metadata.version("mit-ub")
+__all__ = ["ViT", "AdaptiveViT", "__version__"]

--- a/mit_ub/data/augment.py
+++ b/mit_ub/data/augment.py
@@ -1,10 +1,7 @@
-from argparse import ArgumentParser, Namespace
-from pathlib import Path
 from typing import Any, Dict, List, Sequence, Tuple
 
 import torch
 from torch import Tensor
-from torch_dicom.datasets.image import ImagePathInput, save_image
 from torchvision.transforms.v2 import Compose, RandomApply, RandomChoice, Transform
 
 from mit_ub.model.helpers import compile_is_disabled
@@ -145,28 +142,3 @@ class RandomNoise(Compose):
         )
         salt_pepper_noise = RandomApply([SaltPepperNoise(prob=salt_pepper_prob)], p=0.5)
         super().__init__([primary_noise, salt_pepper_noise])
-
-
-def parse_args() -> Namespace:
-    parser = ArgumentParser(description="Preview random noise applied to an image")
-    parser.add_argument("path", type=Path, help="Image to apply noise to")
-    parser.add_argument("-s", "--seed", type=int, default=0, help="Random seed")
-    parser.add_argument("--scale", type=float, default=0.2)
-    parser.add_argument("--salt-pepper-prob", type=float, nargs=2, default=(0.01, 0.05))
-    return parser.parse_args()
-
-
-def main(args: Namespace):
-    torch.random.manual_seed(args.seed)
-    image = next(iter(ImagePathInput(iter([args.path]))))["img"]
-    noise = RandomNoise(scale=args.scale, salt_pepper_prob=args.salt_pepper_prob)
-    image = noise(image)
-    save_image(image, Path("noised.png"))
-
-
-def entrypoint():
-    main(parse_args())
-
-
-if __name__ == "__main__":
-    entrypoint()

--- a/mit_ub/data/cifar10.py
+++ b/mit_ub/data/cifar10.py
@@ -1,14 +1,11 @@
 from copy import copy
-from functools import partial
 from pathlib import Path
-from typing import Any, Callable, Dict, List, Optional, Union, cast
+from typing import Any, Callable, Dict, List, Optional, Union
 
 import torch
 from lightning_fabric.utilities.rank_zero import rank_zero_info
 from pytorch_lightning import LightningDataModule
 from torch.utils.data import DataLoader, Dataset
-from torch_dicom.datasets import collate_fn
-from torch_dicom.datasets.helpers import Transform
 from torchvision.datasets import CIFAR10 as CIFAR10Base
 
 
@@ -72,10 +69,10 @@ class CIFAR10DataModule(LightningDataModule):
         self.seed = seed
         # NOTE: Callable[[E], E] generic seems to break jsonargparse
         # Accept transforms as Callable and cast to Transform
-        self.train_transforms = cast(Transform, train_transforms)
-        self.train_gpu_transforms = cast(Transform, train_gpu_transforms)
-        self.val_transforms = cast(Transform, val_transforms)
-        self.test_transforms = cast(Transform, test_transforms)
+        self.train_transforms = train_transforms
+        self.train_gpu_transforms = train_gpu_transforms
+        self.val_transforms = val_transforms
+        self.test_transforms = test_transforms
         self.train_dataset_kwargs = train_dataset_kwargs
         self.dataset_kwargs = dataset_kwargs
         self.num_workers = num_workers
@@ -133,7 +130,6 @@ class CIFAR10DataModule(LightningDataModule):
 
         return DataLoader(
             dataset,
-            collate_fn=partial(collate_fn, default_fallback=False),
             pin_memory=self.pin_memory,
             num_workers=self.num_workers,
             prefetch_factor=self.prefetch_factor,

--- a/mit_ub/data/rotation.py
+++ b/mit_ub/data/rotation.py
@@ -1,4 +1,4 @@
-from typing import Sequence
+from typing import Any, Sequence, cast
 
 from torchvision.transforms.v2 import RandomRotation as TVRandomRotation
 
@@ -7,4 +7,4 @@ class RandomRotation(TVRandomRotation):
     r"""Wrapper around torchvision's RandomRotation with a type signature that works with jsonargparse."""
 
     def __init__(self, degrees: Sequence[float] | float, expand: bool = False):
-        super().__init__(degrees, expand=expand)
+        super().__init__(cast(Any, degrees), expand=expand)

--- a/mit_ub/model/backbone.py
+++ b/mit_ub/model/backbone.py
@@ -2,11 +2,11 @@ from typing import Any, Callable, Dict, List, Optional, Tuple, cast
 
 import torch
 import torch.nn as nn
-from deep_helpers.tokens import apply_mask
 from einops import rearrange
 from torch import Tensor
 from torch.nn import functional as F
 
+from ..tokens import apply_mask
 from .helpers import compile_is_disabled
 from .mlp import relu2
 from .stem import PatchEmbed2d, PatchEmbed3d

--- a/mit_ub/model/convnext/convnext.py
+++ b/mit_ub/model/convnext/convnext.py
@@ -4,11 +4,10 @@ from typing import Callable, Sequence, Tuple, cast
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
-from deep_helpers.helpers import to_tuple
 from einops import rearrange
 from torch import Tensor
 
-from ..helpers import Dims2D, compile_backend, compile_is_disabled
+from ..helpers import Dims2D, compile_backend, compile_is_disabled, to_tuple
 from ..layer_scale import LayerScale
 from ..mlp import DEFAULT_MLP_ACTIVATION, DEFAULT_MLP_GATE_ACTIVATION, MLP, mlp_forward, relu2
 

--- a/mit_ub/model/stem/adaptive_tokenizer.py
+++ b/mit_ub/model/stem/adaptive_tokenizer.py
@@ -5,11 +5,10 @@ from typing import Callable, Sequence, Tuple, cast
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
-from deep_helpers.helpers import to_tuple
 from einops import rearrange
 from torch import Tensor
 
-from ..helpers import compile_backend, compile_is_disabled
+from ..helpers import compile_backend, compile_is_disabled, to_tuple
 from ..pos_enc import DEFAULT_POS_ENC_ACTIVATION, RelativeFactorizedPosition, relative_factorized_position_forward
 from .patch_embed import PatchEmbed, _init_patch_embed
 

--- a/mit_ub/model/stem/patch_embed.py
+++ b/mit_ub/model/stem/patch_embed.py
@@ -5,11 +5,10 @@ from typing import Callable, Generic, Sequence, Tuple, TypeVar
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
-from deep_helpers.helpers import to_tuple
 from einops import rearrange
 from torch import Tensor
 
-from ..helpers import Dims2D, Dims3D, compile_backend, compile_is_disabled
+from ..helpers import Dims2D, Dims3D, compile_backend, compile_is_disabled, to_tuple
 from ..pos_enc import DEFAULT_POS_ENC_ACTIVATION, RelativeFactorizedPosition, relative_factorized_position_forward
 
 

--- a/mit_ub/tasks/classification.py
+++ b/mit_ub/tasks/classification.py
@@ -77,7 +77,9 @@ class ClassificationTask(Task):
         self.save_hyperparameters()
 
     def prepare_backbone(self, name: str) -> nn.Module:
-        return BACKBONES.get(name).instantiate_with_metadata().fn
+        backbone = BACKBONES.get(name).instantiate_with_metadata().fn
+        assert isinstance(backbone, nn.Module)
+        return backbone
 
     def create_metrics(self, *args, **kwargs) -> tm.MetricCollection:
         return tm.MetricCollection(

--- a/mit_ub/tasks/jepa.py
+++ b/mit_ub/tasks/jepa.py
@@ -194,7 +194,9 @@ class JEPA(Task):
         )
 
     def prepare_backbone(self, name: str) -> nn.Module:
-        return BACKBONES.get(name).instantiate_with_metadata().fn
+        backbone = BACKBONES.get(name).instantiate_with_metadata().fn
+        assert isinstance(backbone, nn.Module)
+        return backbone
 
     def create_mask(self, x: Tensor, unmasked_ratio: float, scale: int) -> Tensor:
         batch_size = x.shape[0]

--- a/mit_ub/tasks/jepa.py
+++ b/mit_ub/tasks/jepa.py
@@ -9,7 +9,6 @@ import torch.nn.functional as F
 import torchmetrics as tm
 from deep_helpers.structs import Mode, State
 from deep_helpers.tasks import Task
-from deep_helpers.tokens import apply_mask, create_mask, mask_is_ragged
 from torch import Tensor
 from torch.distributed import ReduceOp, all_reduce
 from torch.distributed import barrier as dist_barrier
@@ -20,6 +19,7 @@ from ..model import BACKBONES, AdaptiveViT, ViT, compile_is_disabled
 from ..model.backbone import resize_mask
 from ..model.pos_enc import RelativeFactorizedPosition
 from ..model.transformer import TransformerDecoderLayer
+from ..tokens import apply_mask, create_mask, mask_is_ragged
 
 
 EPS: Final = 1e-8

--- a/mit_ub/tokens.py
+++ b/mit_ub/tokens.py
@@ -1,0 +1,154 @@
+from typing import Sequence, cast
+
+import torch
+import torch.nn.functional as F
+from torch import Tensor
+
+
+def mask_is_ragged(mask: Tensor) -> bool:
+    r"""Checks if the mask is ragged.
+
+    A mask is ragged if the number of unmasked tokens is not the same for all batch elements.
+
+    Args:
+        mask: Mask tensor to check
+
+    Shapes:
+        mask - :math:`(N, L)` where :math:`L` is the number of tokens
+    """
+    counts = mask.sum(dim=-1)
+    return cast(bool, (counts != counts[0]).any())
+
+
+def _apply_with_fill(mask: Tensor, x: Tensor, fill_value: float | Tensor) -> Tensor:
+    N, L, _ = x.shape
+    fill_value = fill_value.type_as(x) if isinstance(fill_value, Tensor) else fill_value
+    mask = mask.view(N, L, 1)
+    return torch.where(mask, x, fill_value)
+
+
+def _apply_non_ragged(mask: Tensor, x: Tensor) -> Tensor:
+    N, _, D = x.shape
+    return x[mask].view(N, -1, D)
+
+
+def _apply_ragged(mask: Tensor, x: Tensor, padding_value: float | Tensor) -> Tensor:
+    N, _, D = x.shape
+
+    # Build indices where we want to put non-padding values
+    unmasked_count = mask.sum(dim=-1)
+    max_tokens = cast(int, unmasked_count.max())
+    indices = torch.stack(
+        [
+            torch.arange(N, device=x.device).view(N, 1).expand(-1, max_tokens),
+            torch.arange(max_tokens, device=x.device).view(1, max_tokens).expand(N, -1),
+        ],
+        dim=-1,
+    )
+    indices = indices[indices[..., -1] < unmasked_count.view(-1, 1)]
+
+    if isinstance(padding_value, Tensor):
+        o = padding_value.type_as(x).broadcast_to((N, max_tokens, D))
+    else:
+        o = x.new_full((N, max_tokens, D), padding_value)
+    return torch.index_put(o, indices.unbind(-1), x[mask])
+
+
+def apply_mask(
+    mask: Tensor,
+    x: Tensor,
+    fill_value: float | Tensor | None = None,
+    padding_value: float | Tensor = 0,
+) -> Tensor:
+    r"""Apply the mask to tokens.
+
+    It is expected that ``True`` indicates an unmasked token and ``False`` indicates a masked token.
+    When ``fill_value=None`` and the mask is ragged, the result is padded to match the number of tokens in the
+    largest batch element. Padding is done using ``padding_value`` and is applied to the end of each batch sequence.
+
+    Args:
+        mask: Mask tensor
+        x: Input tensor
+        fill_value: Value to fill the masked tokens with. If ``None``, the masked tokens are removed.
+        padding_value: Padding value used when the mask is ragged.
+
+    Shapes:
+        mask - :math:`(N, L)` where :math:`L` is the number of tokens
+        x - :math:`(N, L, D)`
+        Output - :math:`(N, L', D)` where :math:`L'` is the number of output tokens
+
+    Returns:
+        Tensor with the mask applied
+    """
+    if x.shape[:-1] != mask.shape:
+        raise ValueError(
+            f"Mask and input must match in all dimensions except the last: {x.shape} != {mask.shape}"
+        )  # pragma: no cover
+
+    if fill_value is not None:
+        return _apply_with_fill(mask, x, fill_value)
+    elif not mask_is_ragged(mask):
+        return _apply_non_ragged(mask, x)
+    else:
+        return _apply_ragged(mask, x, padding_value)
+
+
+def create_mask(
+    size: Sequence[int],
+    mask_ratio: float,
+    batch_size: int = 1,
+    scale: int = 1,
+    device: torch.device = torch.device("cpu"),
+) -> Tensor:
+    r"""Create a token mask for an input.
+
+    Args:
+        size: Size of the token grid
+        mask_ratio: Ratio of tokens to mask
+        batch_size: Size of the batch
+        scale: Dilates the mask by this factor. For example, if ``scale == 2`` and ``len(size) == 2``,
+            masking will be done in (2x2) contiguous blocks.
+        device: Device to create the mask on
+
+    Shapes:
+        Output - :math:`(N, L)` where :math:`L` is the product of ``size`` and ``N`` is ``batch_size``
+
+    Raises:
+        ValueError: If ``mask_ratio`` is not in the range (0, 1)
+        ValueError: If ``scale`` is less than 1
+
+    Returns:
+        Token mask tensor, with ``True`` indicating an unmasked token and ``False`` indicating a masked token
+    """
+    if not 0 < mask_ratio < 1.0:
+        raise ValueError(f"Invalid `mask_ratio` {mask_ratio}")
+    if scale < 1:
+        raise ValueError(f"Invalid `scale` {scale}")
+
+    # When scale > 1, reformulate the problem as a recursive call over smaller mask and upsample
+    if scale > 1:
+        scaled_size = tuple(s // scale for s in size)
+        mask = create_mask(scaled_size, mask_ratio, batch_size, scale=1, device=device)
+        mask = mask.view(batch_size, 1, *scaled_size).float()
+        mask = F.interpolate(mask, scale_factor=scale, mode="nearest")
+        mask = mask.view(batch_size, -1).bool()
+        return mask
+
+    # Compute the total number of tokens and number of masked tokens
+    Lmask = cast(int, torch.tensor(size, dtype=torch.long).prod())
+    num_masked_tokens = cast(Tensor, (Lmask * mask_ratio)).round_().long()
+    num_masked_tokens = cast(int, num_masked_tokens)
+
+    # initialize empty mask
+    mask = torch.full((batch_size, Lmask), True, device=device, dtype=torch.bool)
+
+    # select exactly num_masked_tokens random locations, with unique locations for each batch element
+    token_idx = torch.randperm(Lmask).view(1, Lmask).expand(batch_size, -1)
+    indices = torch.argsort(torch.rand_like(token_idx, dtype=torch.float32), dim=-1)[..., :num_masked_tokens]
+    token_idx = torch.gather(token_idx, dim=-1, index=indices)
+    assert token_idx.shape == (batch_size, num_masked_tokens)
+    batch_idx = torch.arange(batch_size).view(batch_size, 1).expand(-1, num_masked_tokens)
+
+    # update mask based on chosen locations
+    mask[batch_idx.flatten(), token_idx.flatten()] = False
+    return mask

--- a/pdm.lock
+++ b/pdm.lock
@@ -2,10 +2,10 @@
 # It is not intended for manual editing.
 
 [metadata]
-groups = ["default", "docs", "quality", "test"]
+groups = ["default", "docs", "quality", "test", "train"]
 strategy = ["cross_platform", "inherit_metadata"]
 lock_version = "4.5.0"
-content_hash = "sha256:30733b0bb3ffd5134417f6e261370a9c058252e3e1bedaeed0753388eeb6e817"
+content_hash = "sha256:c79aac938ba6eb8df7b308bcd6948d0e7d950bc32c88510d32b2309cf332fb06"
 
 [[metadata.targets]]
 requires_python = ">=3.11,<3.12"
@@ -15,7 +15,7 @@ name = "aiohappyeyeballs"
 version = "2.4.3"
 requires_python = ">=3.8"
 summary = "Happy Eyeballs for asyncio"
-groups = ["default"]
+groups = ["train"]
 files = [
     {file = "aiohappyeyeballs-2.4.3-py3-none-any.whl", hash = "sha256:8a7a83727b2756f394ab2895ea0765a0a8c475e3c71e98d43d76f22b4b435572"},
     {file = "aiohappyeyeballs-2.4.3.tar.gz", hash = "sha256:75cf88a15106a5002a8eb1dab212525c00d1f4c0fa96e551c9fbe6f09a621586"},
@@ -26,7 +26,7 @@ name = "aiohttp"
 version = "3.10.10"
 requires_python = ">=3.8"
 summary = "Async http client/server framework (asyncio)"
-groups = ["default"]
+groups = ["train"]
 dependencies = [
     "aiohappyeyeballs>=2.3.0",
     "aiosignal>=1.1.2",
@@ -60,7 +60,7 @@ name = "aiosignal"
 version = "1.3.1"
 requires_python = ">=3.7"
 summary = "aiosignal: a list of registered asynchronous callbacks"
-groups = ["default"]
+groups = ["train"]
 dependencies = [
     "frozenlist>=1.1.0",
 ]
@@ -73,7 +73,7 @@ files = [
 name = "antlr4-python3-runtime"
 version = "4.9.3"
 summary = "ANTLR 4.9.3 runtime for Python 3.7"
-groups = ["default"]
+groups = ["train"]
 dependencies = [
     "typing; python_version < \"3.5\"",
 ]
@@ -86,7 +86,7 @@ name = "attrs"
 version = "24.2.0"
 requires_python = ">=3.7"
 summary = "Classes Without Boilerplate"
-groups = ["default"]
+groups = ["train"]
 dependencies = [
     "importlib-metadata; python_version < \"3.8\"",
 ]
@@ -129,7 +129,7 @@ files = [
 name = "bitsandbytes"
 version = "0.45.0"
 summary = "k-bit optimizers and matrix multiplication routines."
-groups = ["default"]
+groups = ["train"]
 dependencies = [
     "numpy",
     "torch",
@@ -165,42 +165,11 @@ files = [
 ]
 
 [[package]]
-name = "blobfile"
-version = "3.0.0"
-requires_python = ">=3.8.0"
-summary = "Read GCS, ABS and local paths with the same interface, clone of tensorflow.io.gfile"
-groups = ["default"]
-dependencies = [
-    "filelock>=3.0",
-    "lxml>=4.9",
-    "pycryptodomex>=3.8",
-    "urllib3<3,>=1.25.3",
-]
-files = [
-    {file = "blobfile-3.0.0-py3-none-any.whl", hash = "sha256:48ecc3307e622804bd8fe13bf6f40e6463c4439eba7a1f9ad49fd78aa63cc658"},
-    {file = "blobfile-3.0.0.tar.gz", hash = "sha256:32ec777414de7bb2a76ca812a838f0d33327ca28ae844a253503cde625cdf2f1"},
-]
-
-[[package]]
-name = "callable-registry"
-version = "1.0.1"
-requires_python = ">=3.7"
-summary = ""
-groups = ["default"]
-dependencies = [
-    "typing-extensions; python_version < \"3.11\"",
-]
-files = [
-    {file = "callable-registry-1.0.1.tar.gz", hash = "sha256:0c067178272d53b0d878f37003d1df0a82e98c4bdccbbdb3baa61262dcdbe3c0"},
-    {file = "callable_registry-1.0.1-py3-none-any.whl", hash = "sha256:97fbd2904041f350c635e5b61770186d1c33dba55e5296d3df4458128ac3894c"},
-]
-
-[[package]]
 name = "certifi"
 version = "2024.8.30"
 requires_python = ">=3.6"
 summary = "Python package for providing Mozilla's CA Bundle."
-groups = ["default"]
+groups = ["train"]
 files = [
     {file = "certifi-2024.8.30-py3-none-any.whl", hash = "sha256:922820b53db7a7257ffbda3f597266d435245903d80737e34f8a45ff3e3230d8"},
     {file = "certifi-2024.8.30.tar.gz", hash = "sha256:bec941d2aa8195e248a60b31ff9f0558284cf01a52591ceda73ea9afffd69fd9"},
@@ -211,7 +180,7 @@ name = "charset-normalizer"
 version = "3.4.0"
 requires_python = ">=3.7.0"
 summary = "The Real First Universal Charset Detector. Open, modern and actively maintained alternative to Chardet."
-groups = ["default"]
+groups = ["train"]
 files = [
     {file = "charset_normalizer-3.4.0-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:0d99dd8ff461990f12d6e42c7347fd9ab2532fb70e9621ba520f9e8637161d7c"},
     {file = "charset_normalizer-3.4.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:c57516e58fd17d03ebe67e181a4e4e2ccab1168f8c2976c6a334d4f819fe5944"},
@@ -237,7 +206,7 @@ name = "click"
 version = "8.1.7"
 requires_python = ">=3.7"
 summary = "Composable command line interface toolkit"
-groups = ["default", "docs", "quality"]
+groups = ["docs", "quality", "train"]
 dependencies = [
     "colorama; platform_system == \"Windows\"",
     "importlib-metadata; python_version < \"3.8\"",
@@ -267,7 +236,8 @@ name = "colorama"
 version = "0.4.6"
 requires_python = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,!=3.6.*,>=2.7"
 summary = "Cross-platform colored terminal text."
-groups = ["default", "docs", "quality", "test"]
+groups = ["docs", "quality", "test", "train"]
+marker = "sys_platform == \"win32\" or platform_system == \"Windows\""
 files = [
     {file = "colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6"},
     {file = "colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44"},
@@ -278,7 +248,7 @@ name = "contourpy"
 version = "1.3.0"
 requires_python = ">=3.9"
 summary = "Python library for calculating contours of 2D quadrilateral grids"
-groups = ["default"]
+groups = ["train"]
 dependencies = [
     "numpy>=1.23",
 ]
@@ -346,7 +316,7 @@ name = "cycler"
 version = "0.12.1"
 requires_python = ">=3.8"
 summary = "Composable style cycles"
-groups = ["default"]
+groups = ["train"]
 files = [
     {file = "cycler-0.12.1-py3-none-any.whl", hash = "sha256:85cef7cff222d8644161529808465972e51340599459b8ac3ccbac5a854e0d30"},
     {file = "cycler-0.12.1.tar.gz", hash = "sha256:88bb128f02ba341da8ef447245a9e138fae777f6a23943da4540077d3601eb1c"},
@@ -373,32 +343,6 @@ files = [
 ]
 
 [[package]]
-name = "datasets"
-version = "2.14.4"
-requires_python = ">=3.8.0"
-summary = "HuggingFace community-driven open-source library of datasets"
-groups = ["default"]
-dependencies = [
-    "aiohttp",
-    "dill<0.3.8,>=0.3.0",
-    "fsspec[http]>=2021.11.1",
-    "huggingface-hub<1.0.0,>=0.14.0",
-    "multiprocess",
-    "numpy>=1.17",
-    "packaging",
-    "pandas",
-    "pyarrow>=8.0.0",
-    "pyyaml>=5.1",
-    "requests>=2.19.0",
-    "tqdm>=4.62.1",
-    "xxhash",
-]
-files = [
-    {file = "datasets-2.14.4-py3-none-any.whl", hash = "sha256:29336bd316a7d827ccd4da2236596279b20ca2ac78f64c04c9483da7cbc2459b"},
-    {file = "datasets-2.14.4.tar.gz", hash = "sha256:ef29c2b5841de488cd343cfc26ab979bff77efa4d2285af51f1ad7db5c46a83b"},
-]
-
-[[package]]
 name = "decorator"
 version = "5.1.1"
 requires_python = ">=3.5"
@@ -416,7 +360,7 @@ requires_python = ">=3.10,<3.12"
 git = "https://github.com/TidalPaladin/deep-helpers.git"
 revision = "92f25f6818b569920a8c82c198498294d797f373"
 summary = ""
-groups = ["default"]
+groups = ["train"]
 dependencies = [
     "einops>=0.7.0",
     "jsonargparse[signatures]>=4.17.0",
@@ -436,60 +380,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "dicom-anon"
-version = "1.0.10"
-requires_python = ">=3.8"
-summary = "Program to anonymize dicom files with default and custom rules"
-groups = ["default"]
-dependencies = [
-    "pydicom",
-    "setuptools>=69.0.2",
-    "tqdm",
-]
-files = [
-    {file = "dicom-anon-1.0.10.tar.gz", hash = "sha256:109a150fc8a167b1a61eec1e17a8b3ceb276a3a67effa0bbac7ed2e66ac29049"},
-    {file = "dicom_anon-1.0.10-py3-none-any.whl", hash = "sha256:ab978ecfcd817d4e9cd1071e0dce0eda86c093b16e0d52a7a57fb6b6ae23d0f1"},
-]
-
-[[package]]
-name = "dicom-utils"
-version = "1.0.5"
-requires_python = ">=3.10,<3.13"
-git = "https://github.com/medcognetics/dicom-utils.git"
-revision = "1b46395113ec33d68c441509675d945c8da3fdc5"
-summary = ""
-groups = ["default"]
-dependencies = [
-    "Pillow",
-    "callable-registry",
-    "colorama",
-    "dicom-anon",
-    "matplotlib",
-    "numpy",
-    "opencv-python",
-    "pydicom",
-    "pylibjpeg",
-    "pylibjpeg-openjpeg",
-    "python-gdcm>=3.0.10",
-    "tqdm-multiprocessing",
-]
-
-[[package]]
-name = "dill"
-version = "0.3.7"
-requires_python = ">=3.7"
-summary = "serialize all of Python"
-groups = ["default"]
-files = [
-    {file = "dill-0.3.7-py3-none-any.whl", hash = "sha256:76b122c08ef4ce2eedcd4d1abd8e641114bfc6c2867f49f3c41facf65bf19f5e"},
-    {file = "dill-0.3.7.tar.gz", hash = "sha256:cc1c8b182eb3013e24bd475ff2e9295af86c1a38eb1aff128dac8962a9ce3c03"},
-]
-
-[[package]]
 name = "docker-pycreds"
 version = "0.4.0"
 summary = "Python bindings for the docker credentials store API"
-groups = ["default"]
+groups = ["train"]
 dependencies = [
     "six>=1.4.0",
 ]
@@ -503,7 +397,7 @@ name = "docstring-parser"
 version = "0.16"
 requires_python = ">=3.6,<4.0"
 summary = "Parse Python docstrings in reST, Google and Numpydoc format"
-groups = ["default"]
+groups = ["train"]
 files = [
     {file = "docstring_parser-0.16-py3-none-any.whl", hash = "sha256:bf0a1387354d3691d102edef7ec124f219ef639982d096e26e3b60aeffa90637"},
     {file = "docstring_parser-0.16.tar.gz", hash = "sha256:538beabd0af1e2db0146b6bd3caa526c35a34d61af9fd2887f3a8a27a739aa6e"},
@@ -514,7 +408,7 @@ name = "einops"
 version = "0.8.0"
 requires_python = ">=3.8"
 summary = "A new flavour of deep learning operations"
-groups = ["default"]
+groups = ["default", "train"]
 files = [
     {file = "einops-0.8.0-py3-none-any.whl", hash = "sha256:9572fb63046264a862693b0a87088af3bdc8c068fde03de63453cbbde245465f"},
     {file = "einops-0.8.0.tar.gz", hash = "sha256:63486517fed345712a8385c100cb279108d9d47e6ae59099b07657e983deae85"},
@@ -525,7 +419,7 @@ name = "filelock"
 version = "3.16.1"
 requires_python = ">=3.8"
 summary = "A platform independent file lock."
-groups = ["default"]
+groups = ["default", "train"]
 files = [
     {file = "filelock-3.16.1-py3-none-any.whl", hash = "sha256:2082e5703d51fbf98ea75855d9d5527e33d8ff23099bec374a134febee6946b0"},
     {file = "filelock-3.16.1.tar.gz", hash = "sha256:c249fbfcd5db47e5e2d6d62198e565475ee65e4831e2561c8e313fa7eb961435"},
@@ -552,7 +446,7 @@ name = "fonttools"
 version = "4.54.1"
 requires_python = ">=3.8"
 summary = "Tools to manipulate font files"
-groups = ["default"]
+groups = ["train"]
 files = [
     {file = "fonttools-4.54.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:5419771b64248484299fa77689d4f3aeed643ea6630b2ea750eeab219588ba20"},
     {file = "fonttools-4.54.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:301540e89cf4ce89d462eb23a89464fef50915255ece765d10eee8b2bf9d75b2"},
@@ -571,7 +465,7 @@ name = "frozenlist"
 version = "1.5.0"
 requires_python = ">=3.8"
 summary = "A list-like structure which implements collections.abc.MutableSequence"
-groups = ["default"]
+groups = ["train"]
 files = [
     {file = "frozenlist-1.5.0-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:fd74520371c3c4175142d02a976aee0b4cb4a7cc912a60586ffd8d5929979b30"},
     {file = "frozenlist-1.5.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:2f3f7a0fbc219fb4455264cae4d9f01ad41ae6ee8524500f381de64ffaa077d5"},
@@ -597,7 +491,7 @@ name = "fsspec"
 version = "2024.10.0"
 requires_python = ">=3.8"
 summary = "File-system specification"
-groups = ["default"]
+groups = ["default", "train"]
 files = [
     {file = "fsspec-2024.10.0-py3-none-any.whl", hash = "sha256:03b9a6785766a4de40368b88906366755e2819e758b83705c88cd7cb5fe81871"},
     {file = "fsspec-2024.10.0.tar.gz", hash = "sha256:eda2d8a4116d4f2429db8550f2457da57279247dd930bb12f821b58391359493"},
@@ -609,7 +503,7 @@ version = "2024.10.0"
 extras = ["http"]
 requires_python = ">=3.8"
 summary = "File-system specification"
-groups = ["default"]
+groups = ["train"]
 dependencies = [
     "aiohttp!=4.0.0a0,!=4.0.0a1",
     "fsspec==2024.10.0",
@@ -624,7 +518,7 @@ name = "gitdb"
 version = "4.0.11"
 requires_python = ">=3.7"
 summary = "Git Object Database"
-groups = ["default"]
+groups = ["train"]
 dependencies = [
     "smmap<6,>=3.0.1",
 ]
@@ -638,7 +532,7 @@ name = "gitpython"
 version = "3.1.43"
 requires_python = ">=3.7"
 summary = "GitPython is a Python library used to interact with Git repositories"
-groups = ["default"]
+groups = ["train"]
 dependencies = [
     "gitdb<5,>=4.0.1",
     "typing-extensions>=3.7.4.3; python_version < \"3.8\"",
@@ -666,31 +560,11 @@ files = [
 ]
 
 [[package]]
-name = "huggingface-hub"
-version = "0.26.2"
-requires_python = ">=3.8.0"
-summary = "Client library to download and publish models, datasets and other repos on the huggingface.co hub"
-groups = ["default"]
-dependencies = [
-    "filelock",
-    "fsspec>=2023.5.0",
-    "packaging>=20.9",
-    "pyyaml>=5.1",
-    "requests",
-    "tqdm>=4.42.1",
-    "typing-extensions>=3.7.4.3",
-]
-files = [
-    {file = "huggingface_hub-0.26.2-py3-none-any.whl", hash = "sha256:98c2a5a8e786c7b2cb6fdeb2740893cba4d53e312572ed3d8afafda65b128c46"},
-    {file = "huggingface_hub-0.26.2.tar.gz", hash = "sha256:b100d853465d965733964d123939ba287da60a547087783ddff8a323f340332b"},
-]
-
-[[package]]
 name = "idna"
 version = "3.10"
 requires_python = ">=3.6"
 summary = "Internationalized Domain Names in Applications (IDNA)"
-groups = ["default"]
+groups = ["train"]
 files = [
     {file = "idna-3.10-py3-none-any.whl", hash = "sha256:946d195a0d259cbba61165e88e65941f16e9b36ea6ddb97f00452bae8b1287d3"},
     {file = "idna-3.10.tar.gz", hash = "sha256:12f65c9b470abda6dc35cf8e63cc574b1c52b11df2c86030af0ac09b01b13ea9"},
@@ -701,7 +575,7 @@ name = "importlib-resources"
 version = "6.4.5"
 requires_python = ">=3.8"
 summary = "Read resources from Python packages"
-groups = ["default"]
+groups = ["train"]
 dependencies = [
     "zipp>=3.1.0; python_version < \"3.10\"",
 ]
@@ -751,7 +625,7 @@ name = "jinja2"
 version = "3.1.4"
 requires_python = ">=3.7"
 summary = "A very fast and expressive template engine."
-groups = ["default"]
+groups = ["default", "train"]
 dependencies = [
     "MarkupSafe>=2.0",
 ]
@@ -765,7 +639,7 @@ name = "joblib"
 version = "1.4.2"
 requires_python = ">=3.8"
 summary = "Lightweight pipelining with Python functions"
-groups = ["default"]
+groups = ["train"]
 files = [
     {file = "joblib-1.4.2-py3-none-any.whl", hash = "sha256:06d478d5674cbc267e7496a410ee875abd68e4340feff4490bcb7afb88060ae6"},
     {file = "joblib-1.4.2.tar.gz", hash = "sha256:2382c5816b2636fbd20a09e0f4e9dad4736765fdfb7dca582943b9c1366b3f0e"},
@@ -776,7 +650,7 @@ name = "jsonargparse"
 version = "4.35.0"
 requires_python = ">=3.8"
 summary = "Implement minimal boilerplate CLIs derived from type hints and parse from command line, config files and environment variables."
-groups = ["default"]
+groups = ["train"]
 dependencies = [
     "PyYAML>=3.13",
 ]
@@ -791,7 +665,7 @@ version = "4.35.0"
 extras = ["signatures"]
 requires_python = ">=3.8"
 summary = "Implement minimal boilerplate CLIs derived from type hints and parse from command line, config files and environment variables."
-groups = ["default"]
+groups = ["train"]
 dependencies = [
     "docstring-parser>=0.15",
     "jsonargparse==4.35.0",
@@ -809,7 +683,7 @@ version = "4.35.0"
 extras = ["typing-extensions"]
 requires_python = ">=3.8"
 summary = "Implement minimal boilerplate CLIs derived from type hints and parse from command line, config files and environment variables."
-groups = ["default"]
+groups = ["train"]
 dependencies = [
     "jsonargparse==4.35.0",
     "typing-extensions>=3.10.0.0; python_version < \"3.10\"",
@@ -824,7 +698,7 @@ name = "kiwisolver"
 version = "1.4.7"
 requires_python = ">=3.8"
 summary = "A fast implementation of the Cassowary constraint solver"
-groups = ["default"]
+groups = ["train"]
 files = [
     {file = "kiwisolver-1.4.7-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:d2b0e12a42fb4e72d509fc994713d099cbb15ebf1103545e8a45f14da2dfca54"},
     {file = "kiwisolver-1.4.7-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:2a8781ac3edc42ea4b90bc23e7d37b665d89423818e26eb6df90698aa2287c95"},
@@ -850,7 +724,7 @@ name = "lightning-utilities"
 version = "0.11.8"
 requires_python = ">=3.8"
 summary = "Lightning toolbox for across the our ecosystem."
-groups = ["default"]
+groups = ["train"]
 dependencies = [
     "importlib-metadata>=4.0.0; python_version < \"3.8\"",
     "packaging>=17.1",
@@ -860,33 +734,6 @@ dependencies = [
 files = [
     {file = "lightning_utilities-0.11.8-py3-none-any.whl", hash = "sha256:a57edb34a44258f0c61eed8b8b88926766e9052f5e60bbe69e4871a2b2bfd970"},
     {file = "lightning_utilities-0.11.8.tar.gz", hash = "sha256:8dfbdc6c52f9847efc948dc462ab8bebb4f4e9a43bd69c82c1b1da484dac20e6"},
-]
-
-[[package]]
-name = "lxml"
-version = "5.3.0"
-requires_python = ">=3.6"
-summary = "Powerful and Pythonic XML processing library combining libxml2/libxslt with the ElementTree API."
-groups = ["default"]
-files = [
-    {file = "lxml-5.3.0-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:74bcb423462233bc5d6066e4e98b0264e7c1bed7541fff2f4e34fe6b21563c8b"},
-    {file = "lxml-5.3.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:a3d819eb6f9b8677f57f9664265d0a10dd6551d227afb4af2b9cd7bdc2ccbf18"},
-    {file = "lxml-5.3.0-cp311-cp311-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:5b8f5db71b28b8c404956ddf79575ea77aa8b1538e8b2ef9ec877945b3f46442"},
-    {file = "lxml-5.3.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2c3406b63232fc7e9b8783ab0b765d7c59e7c59ff96759d8ef9632fca27c7ee4"},
-    {file = "lxml-5.3.0-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:2ecdd78ab768f844c7a1d4a03595038c166b609f6395e25af9b0f3f26ae1230f"},
-    {file = "lxml-5.3.0-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:168f2dfcfdedf611eb285efac1516c8454c8c99caf271dccda8943576b67552e"},
-    {file = "lxml-5.3.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:aa617107a410245b8660028a7483b68e7914304a6d4882b5ff3d2d3eb5948d8c"},
-    {file = "lxml-5.3.0-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:69959bd3167b993e6e710b99051265654133a98f20cec1d9b493b931942e9c16"},
-    {file = "lxml-5.3.0-cp311-cp311-manylinux_2_28_ppc64le.whl", hash = "sha256:bd96517ef76c8654446fc3db9242d019a1bb5fe8b751ba414765d59f99210b79"},
-    {file = "lxml-5.3.0-cp311-cp311-manylinux_2_28_s390x.whl", hash = "sha256:ab6dd83b970dc97c2d10bc71aa925b84788c7c05de30241b9e96f9b6d9ea3080"},
-    {file = "lxml-5.3.0-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:eec1bb8cdbba2925bedc887bc0609a80e599c75b12d87ae42ac23fd199445654"},
-    {file = "lxml-5.3.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:6a7095eeec6f89111d03dabfe5883a1fd54da319c94e0fb104ee8f23616b572d"},
-    {file = "lxml-5.3.0-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:6f651ebd0b21ec65dfca93aa629610a0dbc13dbc13554f19b0113da2e61a4763"},
-    {file = "lxml-5.3.0-cp311-cp311-musllinux_1_2_s390x.whl", hash = "sha256:f422a209d2455c56849442ae42f25dbaaba1c6c3f501d58761c619c7836642ec"},
-    {file = "lxml-5.3.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:62f7fdb0d1ed2065451f086519865b4c90aa19aed51081979ecd05a21eb4d1be"},
-    {file = "lxml-5.3.0-cp311-cp311-win32.whl", hash = "sha256:c6379f35350b655fd817cd0d6cbeef7f265f3ae5fedb1caae2eb442bbeae9ab9"},
-    {file = "lxml-5.3.0-cp311-cp311-win_amd64.whl", hash = "sha256:9c52100e2c2dbb0649b90467935c4b0de5528833c76a35ea1a2691ec9f1ee7a1"},
-    {file = "lxml-5.3.0.tar.gz", hash = "sha256:4e109ca30d1edec1ac60cdbe341905dc3b8f55b16855e03a54aaf59e51ec8c6f"},
 ]
 
 [[package]]
@@ -978,7 +825,7 @@ name = "markupsafe"
 version = "3.0.2"
 requires_python = ">=3.9"
 summary = "Safely add untrusted strings to HTML/XML markup."
-groups = ["default"]
+groups = ["default", "train"]
 files = [
     {file = "MarkupSafe-3.0.2-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:9025b4018f3a1314059769c7bf15441064b2207cb3f065e6ea1e7359cb46db9d"},
     {file = "MarkupSafe-3.0.2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:93335ca3812df2f366e80509ae119189886b0f3c2b81325d39efdb84a1e2ae93"},
@@ -998,7 +845,7 @@ name = "matplotlib"
 version = "3.9.2"
 requires_python = ">=3.9"
 summary = "Python plotting package"
-groups = ["default"]
+groups = ["train"]
 dependencies = [
     "contourpy>=1.0.1",
     "cycler>=0.10",
@@ -1086,7 +933,7 @@ files = [
 name = "mpmath"
 version = "1.3.0"
 summary = "Python library for arbitrary-precision floating-point arithmetic"
-groups = ["default"]
+groups = ["default", "train"]
 marker = "python_version >= \"3.9\""
 files = [
     {file = "mpmath-1.3.0-py3-none-any.whl", hash = "sha256:a0b2b9fe80bbcd81a6647ff13108738cfb482d481d826cc0e02f5b35e5c88d2c"},
@@ -1098,7 +945,7 @@ name = "multidict"
 version = "6.1.0"
 requires_python = ">=3.8"
 summary = "multidict implementation"
-groups = ["default"]
+groups = ["train"]
 dependencies = [
     "typing-extensions>=4.1.0; python_version < \"3.11\"",
 ]
@@ -1133,20 +980,6 @@ files = [
 ]
 
 [[package]]
-name = "multiprocess"
-version = "0.70.15"
-requires_python = ">=3.7"
-summary = "better multiprocessing and multithreading in Python"
-groups = ["default"]
-dependencies = [
-    "dill>=0.3.7",
-]
-files = [
-    {file = "multiprocess-0.70.15-py311-none-any.whl", hash = "sha256:134f89053d82c9ed3b73edd3a2531eb791e602d4f4156fc92a79259590bd9670"},
-    {file = "multiprocess-0.70.15.tar.gz", hash = "sha256:f20eed3036c0ef477b07a4177cf7c1ba520d9a2677870a4f47fe026f0cd6787e"},
-]
-
-[[package]]
 name = "mypy-extensions"
 version = "1.0.0"
 requires_python = ">=3.5"
@@ -1162,7 +995,7 @@ name = "networkx"
 version = "3.4.2"
 requires_python = ">=3.10"
 summary = "Python package for creating and manipulating graphs and networks"
-groups = ["default", "docs"]
+groups = ["default", "docs", "train"]
 files = [
     {file = "networkx-3.4.2-py3-none-any.whl", hash = "sha256:df5d4365b724cf81b8c6a7312509d0c22386097011ad1abe274afd5e9d3bbc5f"},
     {file = "networkx-3.4.2.tar.gz", hash = "sha256:307c3669428c5362aab27c8a1260aa8f47c4e91d3891f48be0141738d8d053e1"},
@@ -1173,7 +1006,7 @@ name = "numpy"
 version = "1.26.4"
 requires_python = ">=3.9"
 summary = "Fundamental package for array computing in Python"
-groups = ["default", "docs"]
+groups = ["docs", "train"]
 files = [
     {file = "numpy-1.26.4-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:4c66707fabe114439db9068ee468c26bbdf909cac0fb58686a42a24de1760c71"},
     {file = "numpy-1.26.4-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:edd8b5fe47dab091176d21bb6de568acdd906d1887a4584a15a9a96a1dca06ef"},
@@ -1191,7 +1024,7 @@ name = "nvidia-cublas-cu12"
 version = "12.4.5.8"
 requires_python = ">=3"
 summary = "CUBLAS native runtime libraries"
-groups = ["default"]
+groups = ["default", "train"]
 marker = "platform_system == \"Linux\" and platform_machine == \"x86_64\""
 files = [
     {file = "nvidia_cublas_cu12-12.4.5.8-py3-none-manylinux2014_aarch64.whl", hash = "sha256:0f8aa1706812e00b9f19dfe0cdb3999b092ccb8ca168c0db5b8ea712456fd9b3"},
@@ -1204,7 +1037,7 @@ name = "nvidia-cuda-cupti-cu12"
 version = "12.4.127"
 requires_python = ">=3"
 summary = "CUDA profiling tools runtime libs."
-groups = ["default"]
+groups = ["default", "train"]
 marker = "platform_system == \"Linux\" and platform_machine == \"x86_64\""
 files = [
     {file = "nvidia_cuda_cupti_cu12-12.4.127-py3-none-manylinux2014_aarch64.whl", hash = "sha256:79279b35cf6f91da114182a5ce1864997fd52294a87a16179ce275773799458a"},
@@ -1217,7 +1050,7 @@ name = "nvidia-cuda-nvrtc-cu12"
 version = "12.4.127"
 requires_python = ">=3"
 summary = "NVRTC native runtime libraries"
-groups = ["default"]
+groups = ["default", "train"]
 marker = "platform_system == \"Linux\" and platform_machine == \"x86_64\""
 files = [
     {file = "nvidia_cuda_nvrtc_cu12-12.4.127-py3-none-manylinux2014_aarch64.whl", hash = "sha256:0eedf14185e04b76aa05b1fea04133e59f465b6f960c0cbf4e37c3cb6b0ea198"},
@@ -1230,7 +1063,7 @@ name = "nvidia-cuda-runtime-cu12"
 version = "12.4.127"
 requires_python = ">=3"
 summary = "CUDA Runtime native Libraries"
-groups = ["default"]
+groups = ["default", "train"]
 marker = "platform_system == \"Linux\" and platform_machine == \"x86_64\""
 files = [
     {file = "nvidia_cuda_runtime_cu12-12.4.127-py3-none-manylinux2014_aarch64.whl", hash = "sha256:961fe0e2e716a2a1d967aab7caee97512f71767f852f67432d572e36cb3a11f3"},
@@ -1243,7 +1076,7 @@ name = "nvidia-cudnn-cu12"
 version = "9.1.0.70"
 requires_python = ">=3"
 summary = "cuDNN runtime libraries"
-groups = ["default"]
+groups = ["default", "train"]
 marker = "platform_system == \"Linux\" and platform_machine == \"x86_64\""
 dependencies = [
     "nvidia-cublas-cu12",
@@ -1258,7 +1091,7 @@ name = "nvidia-cufft-cu12"
 version = "11.2.1.3"
 requires_python = ">=3"
 summary = "CUFFT native runtime libraries"
-groups = ["default"]
+groups = ["default", "train"]
 marker = "platform_system == \"Linux\" and platform_machine == \"x86_64\""
 dependencies = [
     "nvidia-nvjitlink-cu12",
@@ -1274,7 +1107,7 @@ name = "nvidia-curand-cu12"
 version = "10.3.5.147"
 requires_python = ">=3"
 summary = "CURAND native runtime libraries"
-groups = ["default"]
+groups = ["default", "train"]
 marker = "platform_system == \"Linux\" and platform_machine == \"x86_64\""
 files = [
     {file = "nvidia_curand_cu12-10.3.5.147-py3-none-manylinux2014_aarch64.whl", hash = "sha256:1f173f09e3e3c76ab084aba0de819c49e56614feae5c12f69883f4ae9bb5fad9"},
@@ -1287,7 +1120,7 @@ name = "nvidia-cusolver-cu12"
 version = "11.6.1.9"
 requires_python = ">=3"
 summary = "CUDA solver native runtime libraries"
-groups = ["default"]
+groups = ["default", "train"]
 marker = "platform_system == \"Linux\" and platform_machine == \"x86_64\""
 dependencies = [
     "nvidia-cublas-cu12",
@@ -1305,7 +1138,7 @@ name = "nvidia-cusparse-cu12"
 version = "12.3.1.170"
 requires_python = ">=3"
 summary = "CUSPARSE native runtime libraries"
-groups = ["default"]
+groups = ["default", "train"]
 marker = "platform_system == \"Linux\" and platform_machine == \"x86_64\""
 dependencies = [
     "nvidia-nvjitlink-cu12",
@@ -1321,7 +1154,7 @@ name = "nvidia-nccl-cu12"
 version = "2.21.5"
 requires_python = ">=3"
 summary = "NVIDIA Collective Communication Library (NCCL) Runtime"
-groups = ["default"]
+groups = ["default", "train"]
 marker = "platform_system == \"Linux\" and platform_machine == \"x86_64\""
 files = [
     {file = "nvidia_nccl_cu12-2.21.5-py3-none-manylinux2014_x86_64.whl", hash = "sha256:8579076d30a8c24988834445f8d633c697d42397e92ffc3f63fa26766d25e0a0"},
@@ -1332,7 +1165,7 @@ name = "nvidia-nvjitlink-cu12"
 version = "12.4.127"
 requires_python = ">=3"
 summary = "Nvidia JIT LTO Library"
-groups = ["default"]
+groups = ["default", "train"]
 marker = "platform_system == \"Linux\" and platform_machine == \"x86_64\""
 files = [
     {file = "nvidia_nvjitlink_cu12-12.4.127-py3-none-manylinux2014_aarch64.whl", hash = "sha256:4abe7fef64914ccfa909bc2ba39739670ecc9e820c83ccc7a6ed414122599b83"},
@@ -1345,7 +1178,7 @@ name = "nvidia-nvtx-cu12"
 version = "12.4.127"
 requires_python = ">=3"
 summary = "NVIDIA Tools Extension"
-groups = ["default"]
+groups = ["default", "train"]
 marker = "platform_system == \"Linux\" and platform_machine == \"x86_64\""
 files = [
     {file = "nvidia_nvtx_cu12-12.4.127-py3-none-manylinux2014_aarch64.whl", hash = "sha256:7959ad635db13edf4fc65c06a6e9f9e55fc2f92596db928d169c0bb031e88ef3"},
@@ -1358,7 +1191,7 @@ name = "omegaconf"
 version = "2.3.0"
 requires_python = ">=3.6"
 summary = "A flexible configuration library"
-groups = ["default"]
+groups = ["train"]
 dependencies = [
     "PyYAML>=5.1.0",
     "antlr4-python3-runtime==4.9.*",
@@ -1370,39 +1203,11 @@ files = [
 ]
 
 [[package]]
-name = "opencv-python"
-version = "4.10.0.84"
-requires_python = ">=3.6"
-summary = "Wrapper package for OpenCV python bindings."
-groups = ["default"]
-dependencies = [
-    "numpy>=1.13.3; python_version < \"3.7\"",
-    "numpy>=1.17.0; python_version >= \"3.7\"",
-    "numpy>=1.17.3; python_version >= \"3.8\"",
-    "numpy>=1.19.3; python_version >= \"3.6\" and platform_system == \"Linux\" and platform_machine == \"aarch64\"",
-    "numpy>=1.19.3; python_version >= \"3.9\"",
-    "numpy>=1.21.0; python_version <= \"3.9\" and platform_system == \"Darwin\" and platform_machine == \"arm64\"",
-    "numpy>=1.21.2; python_version >= \"3.10\"",
-    "numpy>=1.21.4; python_version >= \"3.10\" and platform_system == \"Darwin\"",
-    "numpy>=1.23.5; python_version >= \"3.11\"",
-    "numpy>=1.26.0; python_version >= \"3.12\"",
-]
-files = [
-    {file = "opencv-python-4.10.0.84.tar.gz", hash = "sha256:72d234e4582e9658ffea8e9cae5b63d488ad06994ef12d81dc303b17472f3526"},
-    {file = "opencv_python-4.10.0.84-cp37-abi3-macosx_11_0_arm64.whl", hash = "sha256:fc182f8f4cda51b45f01c64e4cbedfc2f00aff799debebc305d8d0210c43f251"},
-    {file = "opencv_python-4.10.0.84-cp37-abi3-macosx_12_0_x86_64.whl", hash = "sha256:71e575744f1d23f79741450254660442785f45a0797212852ee5199ef12eed98"},
-    {file = "opencv_python-4.10.0.84-cp37-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:09a332b50488e2dda866a6c5573ee192fe3583239fb26ff2f7f9ceb0bc119ea6"},
-    {file = "opencv_python-4.10.0.84-cp37-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9ace140fc6d647fbe1c692bcb2abce768973491222c067c131d80957c595b71f"},
-    {file = "opencv_python-4.10.0.84-cp37-abi3-win32.whl", hash = "sha256:2db02bb7e50b703f0a2d50c50ced72e95c574e1e5a0bb35a8a86d0b35c98c236"},
-    {file = "opencv_python-4.10.0.84-cp37-abi3-win_amd64.whl", hash = "sha256:32dbbd94c26f611dc5cc6979e6b7aa1f55a64d6b463cc1dcd3c95505a63e48fe"},
-]
-
-[[package]]
 name = "packaging"
 version = "24.1"
 requires_python = ">=3.8"
 summary = "Core utilities for Python packages"
-groups = ["default", "quality", "test"]
+groups = ["quality", "test", "train"]
 files = [
     {file = "packaging-24.1-py3-none-any.whl", hash = "sha256:5b8f2217dbdbd2f7f384c41c628544e6d52f2d0f53c6d0c3ea61aa5d1d7ff124"},
     {file = "packaging-24.1.tar.gz", hash = "sha256:026ed72c8ed3fcce5bf8950572258698927fd1dbda10a5e981cdf0ac37f4f002"},
@@ -1413,7 +1218,7 @@ name = "pandas"
 version = "2.2.3"
 requires_python = ">=3.9"
 summary = "Powerful data structures for data analysis, time series, and statistics"
-groups = ["default"]
+groups = ["train"]
 dependencies = [
     "numpy>=1.22.4; python_version < \"3.11\"",
     "numpy>=1.23.2; python_version == \"3.11\"",
@@ -1449,7 +1254,7 @@ name = "pillow"
 version = "11.0.0"
 requires_python = ">=3.9"
 summary = "Python Imaging Library (Fork)"
-groups = ["default", "docs"]
+groups = ["docs", "train"]
 files = [
     {file = "pillow-11.0.0-cp311-cp311-macosx_10_10_x86_64.whl", hash = "sha256:1c1d72714f429a521d8d2d018badc42414c3077eb187a59579f28e4270b4b0fc"},
     {file = "pillow-11.0.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:499c3a1b0d6fc8213519e193796eb1a86a1be4b1877d678b30f83fd979811d1a"},
@@ -1470,7 +1275,7 @@ name = "platformdirs"
 version = "4.3.6"
 requires_python = ">=3.8"
 summary = "A small Python package for determining appropriate platform-specific dirs, e.g. a `user data dir`."
-groups = ["default", "quality"]
+groups = ["quality", "train"]
 files = [
     {file = "platformdirs-4.3.6-py3-none-any.whl", hash = "sha256:73e575e1408ab8103900836b97580d5307456908a03e92031bab39e4554cc3fb"},
     {file = "platformdirs-4.3.6.tar.gz", hash = "sha256:357fb2acbc885b0419afd3ce3ed34564c13c9b95c89360cd9563f73aa5e2b907"},
@@ -1492,7 +1297,7 @@ name = "propcache"
 version = "0.2.0"
 requires_python = ">=3.8"
 summary = "Accelerated property cache"
-groups = ["default"]
+groups = ["train"]
 files = [
     {file = "propcache-0.2.0-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:63f13bf09cc3336eb04a837490b8f332e0db41da66995c9fd1ba04552e516354"},
     {file = "propcache-0.2.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:608cce1da6f2672a56b24a015b42db4ac612ee709f3d29f27a00c943d9e851de"},
@@ -1519,7 +1324,7 @@ name = "protobuf"
 version = "5.28.3"
 requires_python = ">=3.8"
 summary = ""
-groups = ["default"]
+groups = ["train"]
 marker = "python_version > \"3.9\" or sys_platform != \"linux\""
 files = [
     {file = "protobuf-5.28.3-cp310-abi3-win32.whl", hash = "sha256:0c4eec6f987338617072592b97943fdbe30d019c56126493111cf24344c1cc24"},
@@ -1536,7 +1341,7 @@ name = "psutil"
 version = "6.1.0"
 requires_python = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,>=2.7"
 summary = "Cross-platform lib for process and system monitoring in Python."
-groups = ["default"]
+groups = ["train"]
 files = [
     {file = "psutil-6.1.0-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:6e2dcd475ce8b80522e51d923d10c7871e45f20918e027ab682f94f1c6351688"},
     {file = "psutil-6.1.0-cp36-abi3-macosx_11_0_arm64.whl", hash = "sha256:0895b8414afafc526712c498bd9de2b063deaac4021a3b3c34566283464aff8e"},
@@ -1546,23 +1351,6 @@ files = [
     {file = "psutil-6.1.0-cp37-abi3-win32.whl", hash = "sha256:1ad45a1f5d0b608253b11508f80940985d1d0c8f6111b5cb637533a0e6ddc13e"},
     {file = "psutil-6.1.0-cp37-abi3-win_amd64.whl", hash = "sha256:a8fb3752b491d246034fa4d279ff076501588ce8cbcdbb62c32fd7a377d996be"},
     {file = "psutil-6.1.0.tar.gz", hash = "sha256:353815f59a7f64cdaca1c0307ee13558a0512f6db064e92fe833784f08539c7a"},
-]
-
-[[package]]
-name = "pyarrow"
-version = "18.0.0"
-requires_python = ">=3.9"
-summary = "Python library for Apache Arrow"
-groups = ["default"]
-files = [
-    {file = "pyarrow-18.0.0-cp311-cp311-macosx_12_0_arm64.whl", hash = "sha256:d5795e37c0a33baa618c5e054cd61f586cf76850a251e2b21355e4085def6280"},
-    {file = "pyarrow-18.0.0-cp311-cp311-macosx_12_0_x86_64.whl", hash = "sha256:5f0510608ccd6e7f02ca8596962afb8c6cc84c453e7be0da4d85f5f4f7b0328a"},
-    {file = "pyarrow-18.0.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:616ea2826c03c16e87f517c46296621a7c51e30400f6d0a61be645f203aa2b93"},
-    {file = "pyarrow-18.0.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a1824f5b029ddd289919f354bc285992cb4e32da518758c136271cf66046ef22"},
-    {file = "pyarrow-18.0.0-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:6dd1b52d0d58dd8f685ced9971eb49f697d753aa7912f0a8f50833c7a7426319"},
-    {file = "pyarrow-18.0.0-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:320ae9bd45ad7ecc12ec858b3e8e462578de060832b98fc4d671dee9f10d9954"},
-    {file = "pyarrow-18.0.0-cp311-cp311-win_amd64.whl", hash = "sha256:2c992716cffb1088414f2b478f7af0175fd0a76fea80841b1706baa8fb0ebaad"},
-    {file = "pyarrow-18.0.0.tar.gz", hash = "sha256:a6aa027b1a9d2970cf328ccd6dbe4a996bc13c39fd427f502782f5bdb9ca20f5"},
 ]
 
 [[package]]
@@ -1587,36 +1375,6 @@ files = [
     {file = "pycodestyle-2.12.1-py2.py3-none-any.whl", hash = "sha256:46f0fb92069a7c28ab7bb558f05bfc0110dac69a0cd23c61ea0040283a9d78b3"},
     {file = "pycodestyle-2.12.1.tar.gz", hash = "sha256:6838eae08bbce4f6accd5d5572075c63626a15ee3e6f842df996bf62f6d73521"},
 ]
-
-[[package]]
-name = "pycryptodomex"
-version = "3.21.0"
-requires_python = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,>=2.7"
-summary = "Cryptographic library for Python"
-groups = ["default"]
-files = [
-    {file = "pycryptodomex-3.21.0-cp36-abi3-macosx_10_9_universal2.whl", hash = "sha256:34325b84c8b380675fd2320d0649cdcbc9cf1e0d1526edbe8fce43ed858cdc7e"},
-    {file = "pycryptodomex-3.21.0-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:103c133d6cd832ae7266feb0a65b69e3a5e4dbbd6f3a3ae3211a557fd653f516"},
-    {file = "pycryptodomex-3.21.0-cp36-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:77ac2ea80bcb4b4e1c6a596734c775a1615d23e31794967416afc14852a639d3"},
-    {file = "pycryptodomex-3.21.0-cp36-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9aa0cf13a1a1128b3e964dc667e5fe5c6235f7d7cfb0277213f0e2a783837cc2"},
-    {file = "pycryptodomex-3.21.0-cp36-abi3-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:46eb1f0c8d309da63a2064c28de54e5e614ad17b7e2f88df0faef58ce192fc7b"},
-    {file = "pycryptodomex-3.21.0-cp36-abi3-musllinux_1_1_aarch64.whl", hash = "sha256:cc7e111e66c274b0df5f4efa679eb31e23c7545d702333dfd2df10ab02c2a2ce"},
-    {file = "pycryptodomex-3.21.0-cp36-abi3-musllinux_1_2_i686.whl", hash = "sha256:770d630a5c46605ec83393feaa73a9635a60e55b112e1fb0c3cea84c2897aa0a"},
-    {file = "pycryptodomex-3.21.0-cp36-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:52e23a0a6e61691134aa8c8beba89de420602541afaae70f66e16060fdcd677e"},
-    {file = "pycryptodomex-3.21.0-cp36-abi3-win32.whl", hash = "sha256:a3d77919e6ff56d89aada1bd009b727b874d464cb0e2e3f00a49f7d2e709d76e"},
-    {file = "pycryptodomex-3.21.0-cp36-abi3-win_amd64.whl", hash = "sha256:b0e9765f93fe4890f39875e6c90c96cb341767833cfa767f41b490b506fa9ec0"},
-    {file = "pycryptodomex-3.21.0.tar.gz", hash = "sha256:222d0bd05381dd25c32dd6065c071ebf084212ab79bab4599ba9e6a3e0009e6c"},
-]
-
-[[package]]
-name = "pydicom"
-version = "3.1.0.dev0"
-requires_python = ">=3.10"
-git = "https://github.com/medcognetics/pydicom.git"
-ref = "fix/pickle"
-revision = "52ab079e2ba5dbc5754f510917ced504bd532d68"
-summary = "A pure Python package for reading and writing DICOM data"
-groups = ["default"]
 
 [[package]]
 name = "pydub"
@@ -1662,39 +1420,6 @@ files = [
 ]
 
 [[package]]
-name = "pylibjpeg"
-version = "2.0.1"
-requires_python = ">=3.8"
-summary = "A Python framework for decoding JPEG and decoding/encoding DICOM RLE data, with a focus on supporting pydicom"
-groups = ["default"]
-dependencies = [
-    "numpy",
-]
-files = [
-    {file = "pylibjpeg-2.0.1-py3-none-any.whl", hash = "sha256:90b611304c99b0752c0e0d78d3c3c25ea0b1a53c82e40c78f347367a8709edcc"},
-    {file = "pylibjpeg-2.0.1.tar.gz", hash = "sha256:3beae5cf829f83bf0c1e5640c3b655bc0f406b8be302215e72f8d31a4185a947"},
-]
-
-[[package]]
-name = "pylibjpeg-openjpeg"
-version = "2.3.0"
-requires_python = "<4.0,>=3.8"
-summary = "A Python wrapper for openjpeg, with a focus on use as a plugin for for pylibjpeg"
-groups = ["default"]
-dependencies = [
-    "numpy",
-]
-files = [
-    {file = "pylibjpeg_openjpeg-2.3.0-cp311-cp311-macosx_12_0_x86_64.whl", hash = "sha256:849748ccadc03ce9403c25f3e0420185c0af6501a80c8185e5b16c6b70f97704"},
-    {file = "pylibjpeg_openjpeg-2.3.0-cp311-cp311-macosx_14_0_arm64.whl", hash = "sha256:1b3f614678a1dfda1f6ae8f433d02d1b67e7baabd0bee45cc67fcf75734725b2"},
-    {file = "pylibjpeg_openjpeg-2.3.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:bacdae7ab99378b6f7c1763b40c97e0ef89f21a9dce0a61a97b0ad7a96a9d85a"},
-    {file = "pylibjpeg_openjpeg-2.3.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:fdd6303be1c79fce74200a61e4fdbf61ceb7f1477bdf31447d34789246ac2eef"},
-    {file = "pylibjpeg_openjpeg-2.3.0-cp311-cp311-win32.whl", hash = "sha256:e43cad5e3f489321a2463b63a9656f3923c784ee678bafed9e0e07eab7d81cc0"},
-    {file = "pylibjpeg_openjpeg-2.3.0-cp311-cp311-win_amd64.whl", hash = "sha256:6b4eac8e839045c3c09e74820a316453789daa53f64d06a43e99f8cda1580b6c"},
-    {file = "pylibjpeg_openjpeg-2.3.0.tar.gz", hash = "sha256:ae0a397ec23297b28a5b7525a63795546406a6d5c1fe59b0591dfee00162bb8b"},
-]
-
-[[package]]
 name = "pyobjc-core"
 version = "10.3.1"
 requires_python = ">=3.8"
@@ -1726,7 +1451,7 @@ name = "pyparsing"
 version = "3.2.0"
 requires_python = ">=3.9"
 summary = "pyparsing module - Classes and methods to define and execute parsing grammars"
-groups = ["default"]
+groups = ["train"]
 files = [
     {file = "pyparsing-3.2.0-py3-none-any.whl", hash = "sha256:93d9577b88da0bbea8cc8334ee8b918ed014968fd2ec383e868fb8afb1ccef84"},
     {file = "pyparsing-3.2.0.tar.gz", hash = "sha256:cbf74e27246d595d9a74b186b810f6fbb86726dbf3b9532efb343f6d7294fe9c"},
@@ -1814,7 +1539,7 @@ name = "python-dateutil"
 version = "2.9.0.post0"
 requires_python = "!=3.0.*,!=3.1.*,!=3.2.*,>=2.7"
 summary = "Extensions to the standard Python datetime module"
-groups = ["default"]
+groups = ["train"]
 dependencies = [
     "six>=1.5",
 ]
@@ -1824,28 +1549,11 @@ files = [
 ]
 
 [[package]]
-name = "python-gdcm"
-version = "3.0.24.1"
-requires_python = ">=3.7"
-summary = "Grassroots DICOM runtime libraries"
-groups = ["default"]
-files = [
-    {file = "python_gdcm-3.0.24.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:2707d7f3775b9de6fe4413d7968bf6ab9bad9257a319ee62b4af62488cd67190"},
-    {file = "python_gdcm-3.0.24.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:d56989567bf9e72f1d74b971e0985eed99522e3fa5839a5ae2de86452f79aa7e"},
-    {file = "python_gdcm-3.0.24.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0c23091cb541081dbda3d3ccf8baa1f5907b0854f81421d9504072b64842000f"},
-    {file = "python_gdcm-3.0.24.1-cp311-cp311-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:3a76ad020da4efe6a5a65d918c010ae8ff48214d4e8881e27da967c11c6ff496"},
-    {file = "python_gdcm-3.0.24.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d3a4c60cf8b6d5fb956c1bc84317081e76bfc1aa34d34e6a014b4a339f91d720"},
-    {file = "python_gdcm-3.0.24.1-cp311-cp311-win32.whl", hash = "sha256:0ba71b67a342238bfd25f3a9795dbdbbfb6ca9a2c14bf16da1392fe69307fd8d"},
-    {file = "python_gdcm-3.0.24.1-cp311-cp311-win_amd64.whl", hash = "sha256:97258af17a3abc70867246ba509847f16479dc69704bdf3584ea1ca76313768f"},
-    {file = "python_gdcm-3.0.24.1.tar.gz", hash = "sha256:101a59c5c2dc34f1eb8e72ccf088a62f45101bf2f844a9e4f6b1711b1268892d"},
-]
-
-[[package]]
 name = "pytorch-lightning"
 version = "2.4.0"
 requires_python = ">=3.8"
 summary = "PyTorch Lightning is the lightweight PyTorch wrapper for ML researchers. Scale your models. Write less boilerplate."
-groups = ["default"]
+groups = ["train"]
 dependencies = [
     "PyYAML>=5.4",
     "fsspec[http]>=2022.5.0",
@@ -1865,7 +1573,7 @@ files = [
 name = "pytz"
 version = "2024.2"
 summary = "World timezone definitions, modern and historical"
-groups = ["default"]
+groups = ["train"]
 files = [
     {file = "pytz-2024.2-py2.py3-none-any.whl", hash = "sha256:31c7c1817eb7fae7ca4b8c7ee50c72f93aa2dd863de768e1ef4245d426aa0725"},
     {file = "pytz-2024.2.tar.gz", hash = "sha256:2aa355083c50a0f93fa581709deac0c9ad65cca8a9e9beac660adcbd493c798a"},
@@ -1876,7 +1584,7 @@ name = "pyyaml"
 version = "6.0.2"
 requires_python = ">=3.8"
 summary = "YAML parser and emitter for Python"
-groups = ["default"]
+groups = ["train"]
 files = [
     {file = "PyYAML-6.0.2-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:cc1c1159b3d456576af7a3e4d1ba7e6924cb39de8f67111c735f6fc832082774"},
     {file = "PyYAML-6.0.2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:1e2120ef853f59c7419231f3bf4e7021f1b936f6ebd222406c3b60212205d2ee"},
@@ -1891,38 +1599,13 @@ files = [
 ]
 
 [[package]]
-name = "regex"
-version = "2024.9.11"
-requires_python = ">=3.8"
-summary = "Alternative regular expression module, to replace re."
-groups = ["default"]
-files = [
-    {file = "regex-2024.9.11-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:2cce2449e5927a0bf084d346da6cd5eb016b2beca10d0013ab50e3c226ffc0df"},
-    {file = "regex-2024.9.11-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:3b37fa423beefa44919e009745ccbf353d8c981516e807995b2bd11c2c77d268"},
-    {file = "regex-2024.9.11-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:64ce2799bd75039b480cc0360907c4fb2f50022f030bf9e7a8705b636e408fad"},
-    {file = "regex-2024.9.11-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a4cc92bb6db56ab0c1cbd17294e14f5e9224f0cc6521167ef388332604e92679"},
-    {file = "regex-2024.9.11-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:d05ac6fa06959c4172eccd99a222e1fbf17b5670c4d596cb1e5cde99600674c4"},
-    {file = "regex-2024.9.11-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:040562757795eeea356394a7fb13076ad4f99d3c62ab0f8bdfb21f99a1f85664"},
-    {file = "regex-2024.9.11-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6113c008a7780792efc80f9dfe10ba0cd043cbf8dc9a76ef757850f51b4edc50"},
-    {file = "regex-2024.9.11-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:8e5fb5f77c8745a60105403a774fe2c1759b71d3e7b4ca237a5e67ad066c7199"},
-    {file = "regex-2024.9.11-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:54d9ff35d4515debf14bc27f1e3b38bfc453eff3220f5bce159642fa762fe5d4"},
-    {file = "regex-2024.9.11-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:df5cbb1fbc74a8305b6065d4ade43b993be03dbe0f8b30032cced0d7740994bd"},
-    {file = "regex-2024.9.11-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:7fb89ee5d106e4a7a51bce305ac4efb981536301895f7bdcf93ec92ae0d91c7f"},
-    {file = "regex-2024.9.11-cp311-cp311-musllinux_1_2_s390x.whl", hash = "sha256:a738b937d512b30bf75995c0159c0ddf9eec0775c9d72ac0202076c72f24aa96"},
-    {file = "regex-2024.9.11-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:e28f9faeb14b6f23ac55bfbbfd3643f5c7c18ede093977f1df249f73fd22c7b1"},
-    {file = "regex-2024.9.11-cp311-cp311-win32.whl", hash = "sha256:18e707ce6c92d7282dfce370cd205098384b8ee21544e7cb29b8aab955b66fa9"},
-    {file = "regex-2024.9.11-cp311-cp311-win_amd64.whl", hash = "sha256:313ea15e5ff2a8cbbad96ccef6be638393041b0a7863183c2d31e0c6116688cf"},
-    {file = "regex-2024.9.11.tar.gz", hash = "sha256:6c188c307e8433bcb63dc1915022deb553b4203a70722fc542c363bf120a01fd"},
-]
-
-[[package]]
 name = "registry"
 version = "0.1.1.dev15"
 requires_python = ">=3.7"
 git = "https://github.com/TidalPaladin/callable-registry.git"
 revision = "9eed0e5bd25711e905e5f166c7093b01fbc7143d"
 summary = ""
-groups = ["default"]
+groups = ["default", "train"]
 dependencies = [
     "typing-extensions; python_version < \"3.11\"",
 ]
@@ -1932,7 +1615,7 @@ name = "requests"
 version = "2.32.3"
 requires_python = ">=3.8"
 summary = "Python HTTP for Humans."
-groups = ["default"]
+groups = ["train"]
 dependencies = [
     "certifi>=2017.4.17",
     "charset-normalizer<4,>=2",
@@ -1965,7 +1648,7 @@ name = "safetensors"
 version = "0.4.5"
 requires_python = ">=3.7"
 summary = ""
-groups = ["default"]
+groups = ["train"]
 files = [
     {file = "safetensors-0.4.5-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:21f848d7aebd5954f92538552d6d75f7c1b4500f51664078b5b49720d180e47c"},
     {file = "safetensors-0.4.5-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:bb07000b19d41e35eecef9a454f31a8b4718a185293f0d0b1c4b61d6e4487971"},
@@ -1987,7 +1670,7 @@ name = "scikit-learn"
 version = "1.5.2"
 requires_python = ">=3.9"
 summary = "A set of python modules for machine learning and data mining"
-groups = ["default"]
+groups = ["train"]
 dependencies = [
     "joblib>=1.2.0",
     "numpy>=1.19.5",
@@ -2008,7 +1691,7 @@ name = "scipy"
 version = "1.14.1"
 requires_python = ">=3.10"
 summary = "Fundamental algorithms for scientific computing in Python"
-groups = ["default", "docs"]
+groups = ["docs", "train"]
 dependencies = [
     "numpy<2.3,>=1.23.5",
 ]
@@ -2041,28 +1724,11 @@ files = [
 ]
 
 [[package]]
-name = "sentencepiece"
-version = "0.2.0"
-summary = "SentencePiece python wrapper"
-groups = ["default"]
-files = [
-    {file = "sentencepiece-0.2.0-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:17982700c4f6dbb55fa3594f3d7e5dd1c8659a274af3738e33c987d2a27c9d5c"},
-    {file = "sentencepiece-0.2.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:7c867012c0e8bcd5bdad0f791609101cb5c66acb303ab3270218d6debc68a65e"},
-    {file = "sentencepiece-0.2.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:7fd6071249c74f779c5b27183295b9202f8dedb68034e716784364443879eaa6"},
-    {file = "sentencepiece-0.2.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:27f90c55a65013cbb8f4d7aab0599bf925cde4adc67ae43a0d323677b5a1c6cb"},
-    {file = "sentencepiece-0.2.0-cp311-cp311-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:b293734059ef656dcd65be62ff771507bea8fed0a711b6733976e1ed3add4553"},
-    {file = "sentencepiece-0.2.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e58b47f933aca74c6a60a79dcb21d5b9e47416256c795c2d58d55cec27f9551d"},
-    {file = "sentencepiece-0.2.0-cp311-cp311-win32.whl", hash = "sha256:c581258cf346b327c62c4f1cebd32691826306f6a41d8c4bec43b010dee08e75"},
-    {file = "sentencepiece-0.2.0-cp311-cp311-win_amd64.whl", hash = "sha256:0993dbc665f4113017892f1b87c3904a44d0640eda510abcacdfb07f74286d36"},
-    {file = "sentencepiece-0.2.0.tar.gz", hash = "sha256:a52c19171daaf2e697dc6cbe67684e0fa341b1248966f6aebb541de654d15843"},
-]
-
-[[package]]
 name = "sentry-sdk"
 version = "2.17.0"
 requires_python = ">=3.6"
 summary = "Python client for Sentry (https://sentry.io)"
-groups = ["default"]
+groups = ["train"]
 dependencies = [
     "certifi",
     "urllib3>=1.26.11",
@@ -2077,7 +1743,7 @@ name = "setproctitle"
 version = "1.3.3"
 requires_python = ">=3.7"
 summary = "A Python module to customize the process title"
-groups = ["default"]
+groups = ["train"]
 files = [
     {file = "setproctitle-1.3.3-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:334f7ed39895d692f753a443102dd5fed180c571eb6a48b2a5b7f5b3564908c8"},
     {file = "setproctitle-1.3.3-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:950f6476d56ff7817a8fed4ab207727fc5260af83481b2a4b125f32844df513a"},
@@ -2099,7 +1765,7 @@ name = "setuptools"
 version = "75.3.0"
 requires_python = ">=3.8"
 summary = "Easily download, build, install, upgrade, and uninstall Python packages"
-groups = ["default"]
+groups = ["train"]
 files = [
     {file = "setuptools-75.3.0-py3-none-any.whl", hash = "sha256:f2504966861356aa38616760c0f66568e535562374995367b4e69c7143cf6bcd"},
     {file = "setuptools-75.3.0.tar.gz", hash = "sha256:fba5dd4d766e97be1b1681d98712680ae8f2f26d7881245f2ce9e40714f1a686"},
@@ -2110,7 +1776,7 @@ name = "six"
 version = "1.16.0"
 requires_python = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*"
 summary = "Python 2 and 3 compatibility utilities"
-groups = ["default"]
+groups = ["train"]
 files = [
     {file = "six-1.16.0-py2.py3-none-any.whl", hash = "sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"},
     {file = "six-1.16.0.tar.gz", hash = "sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926"},
@@ -2138,7 +1804,7 @@ name = "smmap"
 version = "5.0.1"
 requires_python = ">=3.7"
 summary = "A pure Python implementation of a sliding window memory map manager"
-groups = ["default"]
+groups = ["train"]
 files = [
     {file = "smmap-5.0.1-py3-none-any.whl", hash = "sha256:e6d8668fa5f93e706934a62d7b4db19c8d9eb8cf2adbb75ef1b675aa332b69da"},
     {file = "smmap-5.0.1.tar.gz", hash = "sha256:dceeb6c0028fdb6734471eb07c0cd2aae706ccaecab45965ee83f11c8d3b1f62"},
@@ -2158,7 +1824,7 @@ files = [
 name = "strenum"
 version = "0.4.15"
 summary = "An Enum that inherits from str."
-groups = ["default"]
+groups = ["train"]
 files = [
     {file = "StrEnum-0.4.15-py3-none-any.whl", hash = "sha256:a30cda4af7cc6b5bf52c8055bc4bf4b2b6b14a93b574626da33df53cf7740659"},
     {file = "StrEnum-0.4.15.tar.gz", hash = "sha256:878fb5ab705442070e4dd1929bb5e2249511c0bcf2b0eeacf3bcd80875c82eff"},
@@ -2179,7 +1845,7 @@ name = "sympy"
 version = "1.13.1"
 requires_python = ">=3.8"
 summary = "Computer algebra system (CAS) in Python"
-groups = ["default"]
+groups = ["default", "train"]
 marker = "python_version >= \"3.9\""
 dependencies = [
     "mpmath<1.4,>=1.1.0",
@@ -2194,48 +1860,10 @@ name = "threadpoolctl"
 version = "3.5.0"
 requires_python = ">=3.8"
 summary = "threadpoolctl"
-groups = ["default"]
+groups = ["train"]
 files = [
     {file = "threadpoolctl-3.5.0-py3-none-any.whl", hash = "sha256:56c1e26c150397e58c4926da8eeee87533b1e32bef131bd4bf6a2f45f3185467"},
     {file = "threadpoolctl-3.5.0.tar.gz", hash = "sha256:082433502dd922bf738de0d8bcc4fdcbf0979ff44c42bd40f5af8a282f6fa107"},
-]
-
-[[package]]
-name = "tiktoken"
-version = "0.8.0"
-requires_python = ">=3.9"
-summary = "tiktoken is a fast BPE tokeniser for use with OpenAI's models"
-groups = ["default"]
-dependencies = [
-    "regex>=2022.1.18",
-    "requests>=2.26.0",
-]
-files = [
-    {file = "tiktoken-0.8.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:d622d8011e6d6f239297efa42a2657043aaed06c4f68833550cac9e9bc723ef1"},
-    {file = "tiktoken-0.8.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:2efaf6199717b4485031b4d6edb94075e4d79177a172f38dd934d911b588d54a"},
-    {file = "tiktoken-0.8.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5637e425ce1fc49cf716d88df3092048359a4b3bbb7da762840426e937ada06d"},
-    {file = "tiktoken-0.8.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9fb0e352d1dbe15aba082883058b3cce9e48d33101bdaac1eccf66424feb5b47"},
-    {file = "tiktoken-0.8.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:56edfefe896c8f10aba372ab5706b9e3558e78db39dd497c940b47bf228bc419"},
-    {file = "tiktoken-0.8.0-cp311-cp311-win_amd64.whl", hash = "sha256:326624128590def898775b722ccc327e90b073714227175ea8febbc920ac0a99"},
-    {file = "tiktoken-0.8.0.tar.gz", hash = "sha256:9ccbb2740f24542534369c5635cfd9b2b3c2490754a78ac8831d99f89f94eeb2"},
-]
-
-[[package]]
-name = "timm"
-version = "1.0.12"
-requires_python = ">=3.8"
-summary = "PyTorch Image Models"
-groups = ["default"]
-dependencies = [
-    "huggingface-hub",
-    "pyyaml",
-    "safetensors",
-    "torch",
-    "torchvision",
-]
-files = [
-    {file = "timm-1.0.12-py3-none-any.whl", hash = "sha256:6b2770674213f10b7f193be5598ce48bd010ab21cc8af77dba6aeef58b1298a1"},
-    {file = "timm-1.0.12.tar.gz", hash = "sha256:9da490683bd06302ec40e1892f1ccf87985f033e41f3580887d886b9aee9449a"},
 ]
 
 [[package]]
@@ -2243,7 +1871,7 @@ name = "torch"
 version = "2.5.1"
 requires_python = ">=3.8.0"
 summary = "Tensors and Dynamic neural networks in Python with strong GPU acceleration"
-groups = ["default"]
+groups = ["default", "train"]
 dependencies = [
     "filelock",
     "fsspec",
@@ -2275,54 +1903,11 @@ files = [
 ]
 
 [[package]]
-name = "torch-dicom"
-version = "0.1.dev77+g6e503ea"
-requires_python = ">=3.10,<3.12"
-git = "https://github.com/medcognetics/torch-dicom.git"
-revision = "6e503ea358660a7b49bbde3fcc965ab16203bf96"
-summary = ""
-groups = ["default"]
-dependencies = [
-    "StrEnum",
-    "dicom-utils",
-    "einops",
-    "pandas",
-    "pydicom @ git+https://github.com/medcognetics/pydicom.git@fix/pickle",
-    "torch",
-    "torchvision",
-]
-
-[[package]]
-name = "torch-dicom"
-version = "0.1.dev77"
-extras = ["datamodule"]
-requires_python = ">=3.10,<3.12"
-git = "https://github.com/medcognetics/torch-dicom.git"
-revision = "6e503ea358660a7b49bbde3fcc965ab16203bf96"
-summary = ""
-groups = ["default"]
-dependencies = [
-    "deep-helpers @ git+https://github.com/TidalPaladin/deep-helpers.git",
-    "pytorch-lightning>=2.1.2",
-    "torch-dicom @ git+https://github.com/medcognetics/torch-dicom.git",
-]
-
-[[package]]
-name = "torchao"
-version = "0.7.0"
-summary = "Package for applying ao techniques to GPU models"
-groups = ["default"]
-files = [
-    {file = "torchao-0.7.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8b0bfda3c7d9ab797eb6f419bc160e55d2b378da1dbb4565e8dc84999be190d3"},
-    {file = "torchao-0.7.0-py3-none-any.whl", hash = "sha256:49ba10d9d42eb9d698958d9e49e1943ada0f6b9493f6b13eab3a979e3db85b9d"},
-]
-
-[[package]]
 name = "torchmetrics"
 version = "1.6.0"
 requires_python = ">=3.9"
 summary = "PyTorch native Metrics"
-groups = ["default"]
+groups = ["train"]
 dependencies = [
     "lightning-utilities>=0.8.0",
     "numpy>1.20.0",
@@ -2336,34 +1921,11 @@ files = [
 ]
 
 [[package]]
-name = "torchtune"
-version = "0.4.0"
-requires_python = ">=3.9"
-summary = "A native-PyTorch library for LLM fine-tuning"
-groups = ["default"]
-dependencies = [
-    "Pillow>=9.4.0",
-    "blobfile>=2",
-    "datasets",
-    "huggingface-hub",
-    "numpy",
-    "omegaconf",
-    "psutil",
-    "safetensors",
-    "sentencepiece",
-    "tiktoken",
-    "tqdm",
-]
-files = [
-    {file = "torchtune-0.4.0-py3-none-any.whl", hash = "sha256:557c7eef38223368c368ae9f82990fcadfc65b7371b5480e823a98f2a441b49e"},
-]
-
-[[package]]
 name = "torchvision"
 version = "0.20.1"
 requires_python = ">=3.8"
 summary = "image and video datasets and models for torch deep learning"
-groups = ["default"]
+groups = ["train"]
 dependencies = [
     "numpy",
     "pillow!=8.3.*,>=5.3.0",
@@ -2381,7 +1943,7 @@ name = "tqdm"
 version = "4.66.6"
 requires_python = ">=3.7"
 summary = "Fast, Extensible Progress Meter"
-groups = ["default", "docs"]
+groups = ["docs", "train"]
 dependencies = [
     "colorama; platform_system == \"Windows\"",
 ]
@@ -2391,24 +1953,10 @@ files = [
 ]
 
 [[package]]
-name = "tqdm-multiprocessing"
-version = "0.1.2"
-requires_python = ">=3.8"
-summary = ""
-groups = ["default"]
-dependencies = [
-    "tqdm",
-]
-files = [
-    {file = "tqdm_multiprocessing-0.1.2-py3-none-any.whl", hash = "sha256:4851a7c5ce9d0b0fb70a111bd35c7387d9e8dc8a57ce70cf883b2593ada46944"},
-    {file = "tqdm_multiprocessing-0.1.2.tar.gz", hash = "sha256:19d2a52be9291d7be7da3db57b0241f0d801d2df961e6312afa872b25bfceea2"},
-]
-
-[[package]]
 name = "triton"
 version = "3.1.0"
 summary = "A language and compiler for custom Deep Learning operations"
-groups = ["default"]
+groups = ["default", "train"]
 marker = "platform_system == \"Linux\" and platform_machine == \"x86_64\" and python_version < \"3.13\""
 dependencies = [
     "filelock",
@@ -2422,7 +1970,7 @@ name = "typeshed-client"
 version = "2.7.0"
 requires_python = ">=3.8"
 summary = "A library for accessing stubs in typeshed."
-groups = ["default"]
+groups = ["train"]
 dependencies = [
     "importlib-resources>=1.4.0",
     "typing-extensions>=4.5.0",
@@ -2437,7 +1985,7 @@ name = "typing-extensions"
 version = "4.12.2"
 requires_python = ">=3.8"
 summary = "Backported and Experimental Type Hints for Python 3.8+"
-groups = ["default", "docs"]
+groups = ["default", "docs", "train"]
 files = [
     {file = "typing_extensions-4.12.2-py3-none-any.whl", hash = "sha256:04e5ca0351e0f3f85c6853954072df659d0d13fac324d0072316b67d7794700d"},
     {file = "typing_extensions-4.12.2.tar.gz", hash = "sha256:1a7ead55c7e559dd4dee8856e3a88b41225abfe1ce8df57b7c13915fe121ffb8"},
@@ -2448,7 +1996,7 @@ name = "tzdata"
 version = "2024.2"
 requires_python = ">=2"
 summary = "Provider of IANA time zone data"
-groups = ["default"]
+groups = ["train"]
 files = [
     {file = "tzdata-2024.2-py2.py3-none-any.whl", hash = "sha256:a48093786cdcde33cad18c2555e8532f34422074448fbc874186f0abd79565cd"},
     {file = "tzdata-2024.2.tar.gz", hash = "sha256:7d85cc416e9382e69095b7bdf4afd9e3880418a2413feec7069d533d6b4e31cc"},
@@ -2459,7 +2007,7 @@ name = "urllib3"
 version = "2.2.3"
 requires_python = ">=3.8"
 summary = "HTTP library with thread-safe connection pooling, file post, and more."
-groups = ["default"]
+groups = ["train"]
 files = [
     {file = "urllib3-2.2.3-py3-none-any.whl", hash = "sha256:ca899ca043dcb1bafa3e262d73aa25c465bfb49e0bd9dd5d59f1d0acba2f8fac"},
     {file = "urllib3-2.2.3.tar.gz", hash = "sha256:e7d814a81dad81e6caf2ec9fdedb284ecc9c73076b62654547cc64ccdcae26e9"},
@@ -2470,7 +2018,7 @@ name = "wandb"
 version = "0.18.5"
 requires_python = ">=3.7"
 summary = "A CLI and library for interacting with the Weights & Biases API."
-groups = ["default"]
+groups = ["train"]
 dependencies = [
     "click!=8.0.0,>=7.1",
     "docker-pycreds>=0.4.0",
@@ -2525,36 +2073,11 @@ files = [
 ]
 
 [[package]]
-name = "xxhash"
-version = "3.5.0"
-requires_python = ">=3.7"
-summary = "Python binding for xxHash"
-groups = ["default"]
-files = [
-    {file = "xxhash-3.5.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:02c2e816896dc6f85922ced60097bcf6f008dedfc5073dcba32f9c8dd786f3c1"},
-    {file = "xxhash-3.5.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:6027dcd885e21581e46d3c7f682cfb2b870942feeed58a21c29583512c3f09f8"},
-    {file = "xxhash-3.5.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1308fa542bbdbf2fa85e9e66b1077eea3a88bef38ee8a06270b4298a7a62a166"},
-    {file = "xxhash-3.5.0-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:c28b2fdcee797e1c1961cd3bcd3d545cab22ad202c846235197935e1df2f8ef7"},
-    {file = "xxhash-3.5.0-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:924361811732ddad75ff23e90efd9ccfda4f664132feecb90895bade6a1b4623"},
-    {file = "xxhash-3.5.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:89997aa1c4b6a5b1e5b588979d1da048a3c6f15e55c11d117a56b75c84531f5a"},
-    {file = "xxhash-3.5.0-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:685c4f4e8c59837de103344eb1c8a3851f670309eb5c361f746805c5471b8c88"},
-    {file = "xxhash-3.5.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:dbd2ecfbfee70bc1a4acb7461fa6af7748ec2ab08ac0fa298f281c51518f982c"},
-    {file = "xxhash-3.5.0-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:25b5a51dc3dfb20a10833c8eee25903fd2e14059e9afcd329c9da20609a307b2"},
-    {file = "xxhash-3.5.0-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:a8fb786fb754ef6ff8c120cb96629fb518f8eb5a61a16aac3a979a9dbd40a084"},
-    {file = "xxhash-3.5.0-cp311-cp311-musllinux_1_2_s390x.whl", hash = "sha256:a905ad00ad1e1c34fe4e9d7c1d949ab09c6fa90c919860c1534ff479f40fd12d"},
-    {file = "xxhash-3.5.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:963be41bcd49f53af6d795f65c0da9b4cc518c0dd9c47145c98f61cb464f4839"},
-    {file = "xxhash-3.5.0-cp311-cp311-win32.whl", hash = "sha256:109b436096d0a2dd039c355fa3414160ec4d843dfecc64a14077332a00aeb7da"},
-    {file = "xxhash-3.5.0-cp311-cp311-win_amd64.whl", hash = "sha256:b702f806693201ad6c0a05ddbbe4c8f359626d0b3305f766077d51388a6bac58"},
-    {file = "xxhash-3.5.0-cp311-cp311-win_arm64.whl", hash = "sha256:c4dcb4120d0cc3cc448624147dba64e9021b278c63e34a38789b688fd0da9bf3"},
-    {file = "xxhash-3.5.0.tar.gz", hash = "sha256:84f2caddf951c9cbf8dc2e22a89d4ccf5d86391ac6418fe81e3c67d0cf60b45f"},
-]
-
-[[package]]
 name = "yarl"
 version = "1.17.1"
 requires_python = ">=3.9"
 summary = "Yet another URL library"
-groups = ["default"]
+groups = ["train"]
 dependencies = [
     "idna>=2.0",
     "multidict>=4.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,25 +10,9 @@ authors = [
     {name = "Scott Chase Waggener", email = "tidalpaladin@protonmail.com"},
 ]
 dependencies = [
-    "numpy",
-    "pydicom",
     "torch",
-    "torchvision",
-    "torchmetrics",
-    "pytorch-lightning",
-    "timm>=0.5.4",
     "einops",
-    "pandas",
-    "Pillow",
-    "deep-helpers @ git+https://github.com/TidalPaladin/deep-helpers.git",
     "registry @ git+https://github.com/TidalPaladin/callable-registry.git",
-    "dicom-utils @ git+https://github.com/medcognetics/dicom-utils.git",
-    "torch-dicom[datamodule] @ git+https://github.com/medcognetics/torch-dicom.git",
-    "jsonargparse[signatures]",
-    "tqdm-multiprocessing",
-    "torchtune>=0.2.1",
-    "torchao>=0.5.0",
-    "bitsandbytes>=0.44.1",
 ]
 readme = "README.md"
 license = {text = "Apache"}
@@ -37,6 +21,16 @@ dynamic = ["version"]
 [project.optional-dependencies]
 docs = [
     "manim>=0.18.1",
+]
+train = [
+  "Pillow",
+  "pandas",
+  "pytorch-lightning>=2.4",
+  "torchvision",
+  "torchmetrics",
+  "bitsandbytes>=0.44.1",
+  "jsonargparse[signatures]",
+  "deep-helpers @ git+https://github.com/TidalPaladin/deep-helpers.git",
 ]
 [tool.autoflake]
 remove-all-unused-imports = true

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,8 +5,6 @@ import pytest
 import torch
 from pytorch_lightning.loggers import WandbLogger
 from torch._dynamo import config
-from torch_dicom.preprocessing.datamodule import PreprocessedDataModule
-from torch_dicom.testing import MammogramTestFactory
 from torchvision.datasets import CIFAR10
 
 from mit_ub.data import CIFAR10DataModule
@@ -38,14 +36,6 @@ def handle_cuda_mark(item):  # pragma: no cover
 
 def pytest_runtest_setup(item):
     handle_cuda_mark(item)
-
-
-@pytest.fixture(scope="session")
-def datamodule(tmpdir_factory):
-    torch.random.manual_seed(42)
-    root = Path(tmpdir_factory.mktemp("preprocessed"))
-    factory = MammogramTestFactory(root, dicom_size=(64, 32), num_studies=8, seed=0)
-    return factory(batch_size=8, num_workers=0, datamodule_class=PreprocessedDataModule)
 
 
 @pytest.fixture(scope="session")

--- a/tests/test_model/test_backbone.py
+++ b/tests/test_model/test_backbone.py
@@ -2,11 +2,11 @@ from typing import Any, cast
 
 import pytest
 import torch
-from deep_helpers.tokens import create_mask
 from torch.testing import assert_close
 
 from mit_ub.model import BACKBONES
 from mit_ub.model.backbone import AdaptiveViT, ViT
+from mit_ub.tokens import create_mask
 
 
 class TestViT:

--- a/tests/test_tasks/test_jepa.py
+++ b/tests/test_tasks/test_jepa.py
@@ -193,11 +193,11 @@ class TestJEPA:
         assert opt.param_groups[0]["weight_decay"] == 1.0
         assert opt.param_groups[1]["weight_decay"] == 0.5
 
-    def test_fit(self, task, datamodule, logger):
+    def test_fit(self, task, cifar10_datamodule, logger):
         task.weight_decay_final = 4.0
         trainer = pl.Trainer(
             accelerator="cpu",
             fast_dev_run=True,
             logger=logger,
         )
-        trainer.fit(task, datamodule=datamodule)
+        trainer.fit(task, datamodule=cifar10_datamodule)

--- a/tests/test_tokens.py
+++ b/tests/test_tokens.py
@@ -1,0 +1,108 @@
+import pytest
+import torch
+import torch.nn.functional as F
+from torch.testing import assert_close
+
+from mit_ub.tokens import apply_mask, create_mask, mask_is_ragged
+
+
+@pytest.mark.parametrize(
+    "mask, exp",
+    [
+        (([True, True], [True, True]), False),
+        (([True, False], [True, True]), True),
+        (([False, True], [True, True]), True),
+        (([False, False], [True, True]), True),
+        (([False, False], [False, False]), False),
+    ],
+)
+def test_is_ragged(mask, exp):
+    assert mask_is_ragged(torch.tensor(mask, dtype=torch.bool)) == exp
+
+
+@pytest.mark.parametrize(
+    "device",
+    [
+        "cpu",
+        pytest.param("cuda", marks=pytest.mark.cuda),
+    ],
+)
+@pytest.mark.parametrize(
+    "mask, fill_value, padding_value, exp",
+    [
+        # Non-ragged
+        (([True, True], [True, True]), None, 0, torch.tensor([[0, 1], [0, 1]])),
+        (([True, False], [False, True]), None, 0, torch.tensor([[0], [1]])),
+        (([False, True], [True, False]), None, 0, torch.tensor([[1], [0]])),
+        (([False, False], [False, False]), None, 0, torch.tensor([[], []])),
+        (([True, False], [False, True]), -1.0, 0, torch.tensor([[0, -1.0], [-1.0, 1]])),
+        (([True, False], [False, True]), torch.tensor(-1.0), 0, torch.tensor([[0, -1.0], [-1.0, 1]])),
+        # Ragged
+        (([True, False], [True, True]), None, 0, torch.tensor([[0, 0], [0, 1]])),
+        (([False, True], [True, True]), None, 0, torch.tensor([[1, 0], [0, 1]])),
+        (([True, False], [True, True]), None, -1.0, torch.tensor([[0, -1.0], [0, 1]])),
+        (([False, True], [True, True]), None, -1.0, torch.tensor([[1, -1.0], [0, 1]])),
+        (([False, True], [True, True]), -1.0, 0, torch.tensor([[-1.0, 1], [0, 1]])),
+    ],
+)
+def test_apply(device, mask, fill_value, padding_value, exp):
+    mask = torch.tensor(mask, dtype=torch.bool, device=device)
+    N, L = mask.shape
+    x = torch.arange(L, device=device).view(1, L, 1).expand(N, L, 1)
+    o = apply_mask(mask, x, fill_value, padding_value)
+    assert_close(o, exp.view_as(o).type_as(o))
+
+
+class TestCreateMask:
+
+    @pytest.mark.parametrize(
+        "size, exp",
+        [
+            ((32,), 32),
+            ((8, 8), 64),
+        ],
+    )
+    def test_create_size(self, size, exp):
+        assert create_mask(size, 0.5).numel() == exp
+
+    @pytest.mark.parametrize(
+        "size, ratio, exp",
+        [
+            ((1000,), 0.5, 500),
+            ((100, 10), 0.25, 750),
+        ],
+    )
+    def test_create_ratio(self, size, ratio, exp):
+        assert create_mask(size, ratio).sum() == exp
+
+    @pytest.mark.parametrize(
+        "batch_size, size",
+        [
+            (2, (1000,)),
+            (4, (100, 10)),
+        ],
+    )
+    def test_create_batch_size(self, batch_size, size):
+        mask = create_mask(size, 0.5, batch_size)
+        assert mask.shape[0] == batch_size
+        assert (mask.sum(-1) == mask.sum(-1)[0, None]).all()
+
+    def test_create_scale(self):
+        ratio = 0.5
+        torch.random.manual_seed(0)
+        mask = create_mask((8, 8), ratio, scale=2)
+        mask_grid = mask.view(1, 1, 8, 8)
+        target_size = (4, 4)
+        # Average pool the mask as a a float. Mask should be all 1.0 or 0.0 within a block,
+        # so pooled entries should be all 1.0 or 0.0
+        pooled = F.adaptive_avg_pool2d(mask_grid.float(), target_size).view(*target_size)
+        assert ((pooled == 1.0) | (pooled == 0.0)).all()
+
+    @pytest.mark.cuda
+    def test_create_device(self):
+        size = (16, 16)
+        ratio = 0.25
+        scale = 2
+        batch_size = 2
+        mask = create_mask(size, ratio, batch_size, scale=scale, device=torch.device("cuda"))
+        assert mask.device.type == "cuda"


### PR DESCRIPTION
Only a minimal set of dependencies needed for ViT/AdaptiveViT are made required - train time dependencies including JEPA classes are relegated to optional dependencies under the `train` group.