### PR TITLE
Don't use SA in JEPA predictor by default

### DIFF
--- a/mit_ub/tasks/jepa.py
+++ b/mit_ub/tasks/jepa.py
@@ -81,7 +81,7 @@ class JEPAConfig:
     salt_pepper_prob: float | Tuple[float, float] = (0.01, 0.05)
     weight_decay_final: float | None = None
     ema_sync_interval: int = 100
-    self_attn: bool = True
+    self_attn: bool = False
 
     def __post_init__(self) -> None:
         if not 0 < self.context_ratio <= 1:


### PR DESCRIPTION
Empirically it is possible to achieve competitive performance without using self attention in the JEPA predictor.