### PR TITLE
Restore LayerNorm bias

### DIFF
--- a/mit_ub/model/layers/attention.py
+++ b/mit_ub/model/layers/attention.py
@@ -193,7 +193,7 @@ class MultiHeadAttention(nn.Module, Checkpointable):
         # Fused pre-norm
         if norm:
             self.w_norm = nn.Parameter(torch.empty(embed_dim))
-            if norm_type == NormType.RMS_NORM:
+            if norm_type == NormType.LAYER_NORM:
                 self.b_norm = nn.Parameter(torch.empty(embed_dim))
             else:
                 self.register_parameter("b_norm", None)

--- a/mit_ub/model/layers/mlp.py
+++ b/mit_ub/model/layers/mlp.py
@@ -138,7 +138,7 @@ class MLP(nn.Module, Checkpointable):
 
         if norm:
             self.w_norm = nn.Parameter(torch.empty(in_features))
-            if norm_type == NormType.RMS_NORM:
+            if norm_type == NormType.LAYER_NORM:
                 self.b_norm = nn.Parameter(torch.empty(in_features))
             else:
                 self.register_parameter("b_norm", None)

--- a/tests/test_model/test_layers/test_attention.py
+++ b/tests/test_model/test_layers/test_attention.py
@@ -159,7 +159,8 @@ class TestMultiHeadAttention:
     )
     @pytest.mark.parametrize("norm", [False, True])
     @pytest.mark.parametrize("layer_scale", [None, 1.0])
-    def test_reset_parameters(self, norm, layer_scale, num_heads, num_kv_heads, Dq, Dk):
+    @pytest.mark.parametrize("norm_type", [NormType.LAYER_NORM, NormType.RMS_NORM])
+    def test_reset_parameters(self, norm, layer_scale, num_heads, num_kv_heads, Dq, Dk, norm_type):
         model = MultiHeadAttention(
             Dq,
             num_heads,
@@ -168,7 +169,12 @@ class TestMultiHeadAttention:
             kdim=Dk if Dk != Dq else None,
             vdim=Dk if Dk != Dq else None,
             layer_scale=layer_scale,
+            norm_type=norm_type,
+            norm=True,
         )
+        if norm_type == NormType.LAYER_NORM:
+            assert model.w_norm is not None
+            assert model.b_norm is not None
 
         weights_original = {name: param.clone() for name, param in model.named_parameters()}
         model.reset_parameters()

--- a/tests/test_model/test_layers/test_mlp.py
+++ b/tests/test_model/test_layers/test_mlp.py
@@ -76,12 +76,17 @@ class TestMLP:
 
     @pytest.mark.parametrize("gate_activation", [None, F.relu])
     @pytest.mark.parametrize("layer_scale", [None, 1.0])
-    def test_reset_parameters(self, mocker, gate_activation, layer_scale):
+    @pytest.mark.parametrize("norm_type", [NormType.LAYER_NORM, NormType.RMS_NORM])
+    def test_reset_parameters(self, mocker, gate_activation, layer_scale, norm_type):
         torch.random.manual_seed(0)
         D = 32
         spy = mocker.spy(MLP, "reset_parameters")
-        layer = MLP(D, D, D, gate_activation=gate_activation, layer_scale=layer_scale)
+        layer = MLP(D, D, D, gate_activation=gate_activation, layer_scale=layer_scale, norm=True, norm_type=norm_type)
         spy.assert_called_once()
+
+        if norm_type == NormType.LAYER_NORM:
+            assert layer.w_norm is not None
+            assert layer.b_norm is not None
 
         weight_init = {k: v.clone() for k, v in layer.named_parameters()}
         layer.reset_parameters()


### PR DESCRIPTION
Fixes a bug where biases weren't applied to LayerNorm. Fixing this issue seems to have improved performance